### PR TITLE
Reduce enactment time of "Restore Ecumenopolis" decision to 5 years

### DIFF
--- a/common/decisions/02_special_decisions.txt
+++ b/common/decisions/02_special_decisions.txt
@@ -929,7 +929,7 @@ decision_arcology_project_relic = {
 	owned_planets_only = yes
 	icon = decision_arcology_project
 
-	enactment_time = 3600
+	enactment_time = 1800
 	resources = {
 		category = decisions
 		cost = {


### PR DESCRIPTION
Building a new Ecumenopolis has already been reduced to 5 years before, and Relic world restoration shouldn't take twice as long.