### PR TITLE
Growth Malus should impact pop assembler job upkeep

### DIFF
--- a/common/pop_jobs/02_specialist_jobs.txt
+++ b/common/pop_jobs/02_specialist_jobs.txt
@@ -1121,10 +1121,222 @@ roboticist = {
 	
 	resources = {
 		category = planet_pop_assemblers
+
+		### UPKEEP ###
+		### should based on growth malus level
+		### every level of minerals upkeep is 10 * (1 - growth malus effect)
 		upkeep = {
-			trigger = {  planet = { free_housing >= 0 } }
+			trigger = {
+				planet = { free_housing >= 0 }
+				owner = { check_variable = { which = col_count value < 1 } }
+			}
 			minerals = 10
 		}
+		upkeep = {
+			trigger = {
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_2 }
+			}
+			minerals = 9
+		}
+		upkeep = {
+			trigger = {
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_3 }
+			}
+			minerals = 8.1
+		}
+		upkeep = {
+			trigger = {
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_4 }
+			}
+			minerals = 7.4
+		}
+		upkeep = {
+			trigger = {
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_5 }
+			}
+			minerals = 6.7
+		}
+		upkeep = {
+			trigger = {
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_6 }
+			}
+			minerals = 6.1
+		}
+		upkeep = {
+			trigger = {
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_7 }
+			}
+			minerals = 5.7
+		}
+		upkeep = {
+			trigger = {
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_8 }
+			}
+			minerals = 5.2
+		}
+		upkeep = {
+			trigger = {
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_9 }
+			}
+			minerals = 4.8
+		}
+		upkeep = {
+			trigger = {
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_10 }
+			}
+			minerals = 4.5
+		}
+		upkeep = {
+			trigger = {
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_11 }
+			}
+			minerals = 4.2
+		}
+		upkeep = {
+			trigger = {
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_12 }
+			}
+			minerals = 3.9
+		}
+		upkeep = {
+			trigger = {
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_13 }
+			}
+			minerals = 3.6
+		}
+		upkeep = {
+			trigger = {
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_14 }
+			}
+			minerals = 3.4
+		}
+		upkeep = {
+			trigger = {
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_15 }
+			}
+			minerals = 3.2
+		}
+		upkeep = {
+			trigger = {
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_16 }
+			}
+			minerals = 3.0
+		}
+		upkeep = {
+			trigger = {
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_17 }
+			}
+			minerals = 2.8
+		}
+		upkeep = {
+			trigger = {
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_18 }
+			}
+			minerals = 2.7
+		}
+		upkeep = {
+			trigger = {
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_19 }
+			}
+			minerals = 2.6
+		}
+		upkeep = {
+			trigger = {
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_20 }
+			}
+			minerals = 2.5
+		}
+		upkeep = {
+			trigger = {
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_21 }
+			}
+			minerals = 2.4
+		}
+		upkeep = {
+			trigger = {
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_22 }
+			}
+			minerals = 2.3
+		}
+		upkeep = {
+			trigger = {
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_23 }
+			}
+			minerals = 2.2
+		}
+		upkeep = {
+			trigger = {
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_24 }
+			}
+			minerals = 2.1
+		}
+		upkeep = {
+			trigger = {
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_25 }
+			}
+			minerals = 2.0
+		}
+		upkeep = {
+			trigger = {
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_26 }
+			}
+			minerals = 1.9
+		}
+		upkeep = {
+			trigger = {
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_27 }
+			}
+			minerals = 1.8
+		}
+		upkeep = {
+			trigger = {
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_28 }
+			}
+			minerals = 1.7
+		}
+		upkeep = {
+			trigger = {
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_29 }
+			}
+			minerals = 1.6
+		}
+		upkeep = {
+			trigger = {
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_30 }
+			}
+			minerals = 1.5
+		}
+		### END UPKEEP ###
+
 		produces = {
 			trigger = { planet = {
 				free_housing < 0

--- a/common/pop_jobs/04_gestalt_jobs.txt
+++ b/common/pop_jobs/04_gestalt_jobs.txt
@@ -1,8 +1,5 @@
-###################
-# Gestalt Jobs
-###################
 spawning_drone = {
-	category = complex_drone
+	category = breeding_drone
 	condition_string = DRONE_JOB_TRIGGER
 	building_icon = building_spawning_pool
 		
@@ -14,43 +11,33 @@ spawning_drone = {
 	}
 
 	possible = {
+		or = {
+			has_job = spawning_drone
+			retile_job_seeking = yes
+		}
 		drone_job_check_trigger = yes
+		owner = { is_hive_empire = yes }
 	}
 	
 	planet_modifier = {
-		planet_amenities_no_happiness_add = 5
-		pop_growth_speed = 0.25
+		planet_amenities_no_happiness_add = 50
+		pop_growth_speed = 0.50
+		planet_stability_add = 5
 	}
-	triggered_planet_modifier = {
-		potential = {
-			has_trait = trait_charismatic
-		}
-		modifier = {
-			planet_amenities_no_happiness_add = 1
-		}
-	}
-	triggered_planet_modifier = {
-		potential = {
-			has_trait = trait_repugnant
-		}
-		modifier = {
-			planet_amenities_no_happiness_add = -1
-		}
-	}	
 	
 	resources = {
 		category = planet_jobs
 
 		### ORGANIC UPKEEP ###
 		### should based on growth malus level
-		### every level of food upkeep is 5 * (1 - growth malus effect)
+		### every level of food upkeep is 4 * (1 - growth malus effect)
 		upkeep = {
 			trigger = {
 				is_lithoid = no
 				planet = { free_housing >= 0 }
 				owner = { check_variable = { which = col_count value < 1 } }
 			}
-			food = 5
+			food = 4
 		}
 		upkeep = {
 			trigger = {
@@ -58,7 +45,7 @@ spawning_drone = {
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_2 }
 			}
-			food = 4.5
+			food = 3.6
 		}
 		upkeep = {
 			trigger = {
@@ -66,7 +53,7 @@ spawning_drone = {
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_3 }
 			}
-			food = 4.05
+			food = 3.24
 		}
 		upkeep = {
 			trigger = {
@@ -74,7 +61,7 @@ spawning_drone = {
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_4 }
 			}
-			food = 3.7
+			food = 2.96
 		}
 		upkeep = {
 			trigger = {
@@ -82,7 +69,7 @@ spawning_drone = {
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_5 }
 			}
-			food = 3.35
+			food = 2.68
 		}
 		upkeep = {
 			trigger = {
@@ -90,7 +77,7 @@ spawning_drone = {
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_6 }
 			}
-			food = 3.05
+			food = 2.44
 		}
 		upkeep = {
 			trigger = {
@@ -98,7 +85,7 @@ spawning_drone = {
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_7 }
 			}
-			food = 2.85
+			food = 2.28
 		}
 		upkeep = {
 			trigger = {
@@ -106,7 +93,7 @@ spawning_drone = {
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_8 }
 			}
-			food = 2.6
+			food = 2.08
 		}
 		upkeep = {
 			trigger = {
@@ -114,37 +101,13 @@ spawning_drone = {
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_9 }
 			}
-			food = 2.4
+			food = 1.92
 		}
 		upkeep = {
 			trigger = {
 				is_lithoid = no
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_10 }
-			}
-			food = 2.25
-		}
-		upkeep = {
-			trigger = {
-				is_lithoid = no
-				planet = { free_housing >= 0 }
-				owner = { has_modifier = retile_growth_malus_11 }
-			}
-			food = 2.1
-		}
-		upkeep = {
-			trigger = {
-				is_lithoid = no
-				planet = { free_housing >= 0 }
-				owner = { has_modifier = retile_growth_malus_12 }
-			}
-			food = 1.95
-		}
-		upkeep = {
-			trigger = {
-				is_lithoid = no
-				planet = { free_housing >= 0 }
-				owner = { has_modifier = retile_growth_malus_13 }
 			}
 			food = 1.8
 		}
@@ -152,9 +115,33 @@ spawning_drone = {
 			trigger = {
 				is_lithoid = no
 				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_11 }
+			}
+			food = 1.68
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_12 }
+			}
+			food = 1.56
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_13 }
+			}
+			food = 1.44
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_14 }
 			}
-			food = 1.7
+			food = 1.36
 		}
 		upkeep = {
 			trigger = {
@@ -162,53 +149,13 @@ spawning_drone = {
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_15 }
 			}
-			food = 1.6
+			food = 1.28
 		}
 		upkeep = {
 			trigger = {
 				is_lithoid = no
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_16 }
-			}
-			food = 1.5
-		}
-		upkeep = {
-			trigger = {
-				is_lithoid = no
-				planet = { free_housing >= 0 }
-				owner = { has_modifier = retile_growth_malus_17 }
-			}
-			food = 1.4
-		}
-		upkeep = {
-			trigger = {
-				is_lithoid = no
-				planet = { free_housing >= 0 }
-				owner = { has_modifier = retile_growth_malus_18 }
-			}
-			food = 1.35
-		}
-		upkeep = {
-			trigger = {
-				is_lithoid = no
-				planet = { free_housing >= 0 }
-				owner = { has_modifier = retile_growth_malus_19 }
-			}
-			food = 1.3
-		}
-		upkeep = {
-			trigger = {
-				is_lithoid = no
-				planet = { free_housing >= 0 }
-				owner = { has_modifier = retile_growth_malus_20 }
-			}
-			food = 1.25
-		}
-		upkeep = {
-			trigger = {
-				is_lithoid = no
-				planet = { free_housing >= 0 }
-				owner = { has_modifier = retile_growth_malus_21 }
 			}
 			food = 1.2
 		}
@@ -216,9 +163,49 @@ spawning_drone = {
 			trigger = {
 				is_lithoid = no
 				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_17 }
+			}
+			food = 1.12
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_18 }
+			}
+			food = 1.08
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_19 }
+			}
+			food = 1.04
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_20 }
+			}
+			food = 1
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_21 }
+			}
+			food = 0.96
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_22 }
 			}
-			food = 1.15
+			food = 0.92
 		}
 		upkeep = {
 			trigger = {
@@ -226,7 +213,7 @@ spawning_drone = {
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_23 }
 			}
-			food = 1.1
+			food = 0.88
 		}
 		upkeep = {
 			trigger = {
@@ -234,45 +221,13 @@ spawning_drone = {
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_24 }
 			}
-			food = 1.05
+			food = 0.84
 		}
 		upkeep = {
 			trigger = {
 				is_lithoid = no
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_25 }
-			}
-			food = 1.0
-		}
-		upkeep = {
-			trigger = {
-				is_lithoid = no
-				planet = { free_housing >= 0 }
-				owner = { has_modifier = retile_growth_malus_26 }
-			}
-			food = 0.95
-		}
-		upkeep = {
-			trigger = {
-				is_lithoid = no
-				planet = { free_housing >= 0 }
-				owner = { has_modifier = retile_growth_malus_27 }
-			}
-			food = 0.9
-		}
-		upkeep = {
-			trigger = {
-				is_lithoid = no
-				planet = { free_housing >= 0 }
-				owner = { has_modifier = retile_growth_malus_28 }
-			}
-			food = 0.85
-		}
-		upkeep = {
-			trigger = {
-				is_lithoid = no
-				planet = { free_housing >= 0 }
-				owner = { has_modifier = retile_growth_malus_29 }
 			}
 			food = 0.8
 		}
@@ -280,22 +235,54 @@ spawning_drone = {
 			trigger = {
 				is_lithoid = no
 				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_26 }
+			}
+			food = 0.76
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_27 }
+			}
+			food = 0.72
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_28 }
+			}
+			food = 0.68
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_29 }
+			}
+			food = 0.64
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_30 }
 			}
-			food = 0.75
+			food = 0.6
 		}
 		### END ORGANIC UPKEEP ###
 
 		### LITHOID UPKEEP ###
 		### should based on growth malus level
-		### every level of minerals upkeep is 5 * (1 - growth malus effect)
+		### every level of minerals upkeep is 10 * (1 - growth malus effect)
 		upkeep = {
 			trigger = {
 				is_lithoid = yes
 				planet = { free_housing >= 0 }
 				owner = { check_variable = { which = col_count value < 1 } }
 			}
-			minerals = 5
+			minerals = 10
 		}
 		upkeep = {
 			trigger = {
@@ -303,7 +290,7 @@ spawning_drone = {
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_2 }
 			}
-			minerals = 4.5
+			minerals = 9
 		}
 		upkeep = {
 			trigger = {
@@ -311,7 +298,7 @@ spawning_drone = {
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_3 }
 			}
-			minerals = 4.05
+			minerals = 8.1
 		}
 		upkeep = {
 			trigger = {
@@ -319,7 +306,7 @@ spawning_drone = {
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_4 }
 			}
-			minerals = 3.7
+			minerals = 7.4
 		}
 		upkeep = {
 			trigger = {
@@ -327,7 +314,7 @@ spawning_drone = {
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_5 }
 			}
-			minerals = 3.35
+			minerals = 6.7
 		}
 		upkeep = {
 			trigger = {
@@ -335,7 +322,7 @@ spawning_drone = {
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_6 }
 			}
-			minerals = 3.05
+			minerals = 6.1
 		}
 		upkeep = {
 			trigger = {
@@ -343,7 +330,7 @@ spawning_drone = {
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_7 }
 			}
-			minerals = 2.85
+			minerals = 5.7
 		}
 		upkeep = {
 			trigger = {
@@ -351,7 +338,7 @@ spawning_drone = {
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_8 }
 			}
-			minerals = 2.6
+			minerals = 5.2
 		}
 		upkeep = {
 			trigger = {
@@ -359,7 +346,7 @@ spawning_drone = {
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_9 }
 			}
-			minerals = 2.4
+			minerals = 4.8
 		}
 		upkeep = {
 			trigger = {
@@ -367,7 +354,7 @@ spawning_drone = {
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_10 }
 			}
-			minerals = 2.25
+			minerals = 4.5
 		}
 		upkeep = {
 			trigger = {
@@ -375,7 +362,7 @@ spawning_drone = {
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_11 }
 			}
-			minerals = 2.1
+			minerals = 4.2
 		}
 		upkeep = {
 			trigger = {
@@ -383,7 +370,7 @@ spawning_drone = {
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_12 }
 			}
-			minerals = 1.95
+			minerals = 3.9
 		}
 		upkeep = {
 			trigger = {
@@ -391,7 +378,7 @@ spawning_drone = {
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_13 }
 			}
-			minerals = 1.8
+			minerals = 3.6
 		}
 		upkeep = {
 			trigger = {
@@ -399,7 +386,7 @@ spawning_drone = {
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_14 }
 			}
-			minerals = 1.7
+			minerals = 3.4
 		}
 		upkeep = {
 			trigger = {
@@ -407,7 +394,7 @@ spawning_drone = {
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_15 }
 			}
-			minerals = 1.6
+			minerals = 3.2
 		}
 		upkeep = {
 			trigger = {
@@ -415,7 +402,7 @@ spawning_drone = {
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_16 }
 			}
-			minerals = 1.5
+			minerals = 3.0
 		}
 		upkeep = {
 			trigger = {
@@ -423,7 +410,7 @@ spawning_drone = {
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_17 }
 			}
-			minerals = 1.4
+			minerals = 2.8
 		}
 		upkeep = {
 			trigger = {
@@ -431,7 +418,7 @@ spawning_drone = {
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_18 }
 			}
-			minerals = 1.35
+			minerals = 2.7
 		}
 		upkeep = {
 			trigger = {
@@ -439,7 +426,7 @@ spawning_drone = {
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_19 }
 			}
-			minerals = 1.3
+			minerals = 2.6
 		}
 		upkeep = {
 			trigger = {
@@ -447,7 +434,7 @@ spawning_drone = {
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_20 }
 			}
-			minerals = 1.25
+			minerals = 2.5
 		}
 		upkeep = {
 			trigger = {
@@ -455,7 +442,7 @@ spawning_drone = {
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_21 }
 			}
-			minerals = 1.2
+			minerals = 2.4
 		}
 		upkeep = {
 			trigger = {
@@ -463,7 +450,7 @@ spawning_drone = {
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_22 }
 			}
-			minerals = 1.15
+			minerals = 2.3
 		}
 		upkeep = {
 			trigger = {
@@ -471,7 +458,7 @@ spawning_drone = {
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_23 }
 			}
-			minerals = 1.1
+			minerals = 2.2
 		}
 		upkeep = {
 			trigger = {
@@ -479,7 +466,7 @@ spawning_drone = {
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_24 }
 			}
-			minerals = 1.05
+			minerals = 2.1
 		}
 		upkeep = {
 			trigger = {
@@ -487,7 +474,7 @@ spawning_drone = {
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_25 }
 			}
-			minerals = 1.0
+			minerals = 2.0
 		}
 		upkeep = {
 			trigger = {
@@ -495,7 +482,7 @@ spawning_drone = {
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_26 }
 			}
-			minerals = 0.95
+			minerals = 1.9
 		}
 		upkeep = {
 			trigger = {
@@ -503,7 +490,7 @@ spawning_drone = {
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_27 }
 			}
-			minerals = 0.9
+			minerals = 1.8
 		}
 		upkeep = {
 			trigger = {
@@ -511,7 +498,7 @@ spawning_drone = {
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_28 }
 			}
-			minerals = 0.85
+			minerals = 1.7
 		}
 		upkeep = {
 			trigger = {
@@ -519,7 +506,7 @@ spawning_drone = {
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_29 }
 			}
-			minerals = 0.8
+			minerals = 1.6
 		}
 		upkeep = {
 			trigger = {
@@ -527,213 +514,13 @@ spawning_drone = {
 				planet = { free_housing >= 0 }
 				owner = { has_modifier = retile_growth_malus_30 }
 			}
-			minerals = 0.75
+			minerals = 1.5
 		}
 		### END LITHOID UPKEEP ###
 	}
 	
 	weight = {
-		weight = @spawner_drone_job_weight
-		modifier = {
-			factor = 1.25
-			has_trait = trait_charismatic
-		}
-		modifier = {
-			factor = 0.9
-			has_trait = trait_repugnant
-		}	
-		modifier = {
-			factor = 0.5 # job is less useful if pop control is active, but still gives amenities 
-			planet = {
-				has_modifier = planet_population_control_gestalt
-			}
-		}
-		modifier = {
-			factor = 0.01 # crisis purge
-			planet.controller = {
-				OR = {
-					is_country_type = swarm
-					is_country_type = ai_empire
-				}
-			}
-		}
-	}
-}
-
-replicator = {
-	category = complex_drone
-	condition_string = DRONE_JOB_TRIGGER
-	building_icon = building_robot_assembly_plant
-	
-	possible_pre_triggers = {
-		has_owner = yes
-		is_enslaved = no
-		is_being_purged = no
-		is_being_assimilated = no
-	}
-
-	possible = {
-		drone_job_check_trigger = yes
-	}
-	
-	planet_modifier = {
-		planet_pop_assembly_add = 1
-		planet_amenities_no_happiness_add = 5
-	} 
-
-	resources = {
-		category = planet_pop_assemblers
-		produces = {
-			engineering_research = 1
-		}
-		upkeep = {
-			minerals = 3
-		}
-	}
-	
-	weight = {
-		weight = @spawner_drone_job_weight
-		modifier = {
-			factor = 40
-			exists = owner
-			owner = { has_valid_civic = civic_machine_assimilator }
-			has_trait = trait_cybernetic
-		}
-		modifier = {
-			factor = 0.5 # job is less useful if pop control is active, but still gives amenities
-			planet = {
-				has_modifier = planet_population_control_gestalt
-			}
-		}
-		modifier = {
-			factor = 1.25
-			OR = {
-				has_trait = trait_charismatic
-				has_trait = trait_robot_emotion_emulators
-			}
-		}
-		modifier = {
-			factor = 0.9
-			OR = {
-				has_trait = trait_repugnant
-				has_trait = trait_robot_uncanny
-			}
-		}
-	}
-}
-
-coordinator = {
-	category = complex_drone
-	condition_string = DRONE_JOB_TRIGGER
-	building_icon = building_machine_capital
-	
-	possible_pre_triggers = {
-		has_owner = yes
-		is_enslaved = no
-		is_being_purged = no
-		is_being_assimilated = no
-	}
-
-	possible = {
-		drone_job_check_trigger = yes
-	}	
-	
-	planet_modifier = {
-		planet_jobs_simple_drone_produces_mult = 0.01
-	}
-
-	triggered_planet_modifier = {
-		potential = {
-			planet = { has_modifier = planet_artifact_relays_machine }
-		}
-		modifier = {
-			planet_stability_add = 2
-			planet_jobs_simple_drone_produces_mult = 0.01
-		}
-	}
-	
-	resources = {
-		category = planet_jobs
-		produces = {
-			unity = 3
-			society_research = 1
-			physics_research = 1
-			engineering_research = 1 
-		}
-		upkeep = {
-			energy = 3
-		}
-	}	
-	
-	weight = {
-		weight = @synapse_drone_job_weight
-		modifier = {
-			factor = 0.9
-			exists = owner
-			years_passed < 1
-			owner = { has_valid_civic = civic_machine_assimilator }
-			has_trait = trait_cybernetic
-		}		
-	}
-}
-
-synapse_drone = {
-	category = complex_drone
-	condition_string = DRONE_JOB_TRIGGER
-	building_icon = building_hive_capital
-	
-	possible_pre_triggers = {
-		has_owner = yes
-		is_enslaved = no
-		is_being_purged = no
-		is_being_assimilated = no
-	}
-
-	possible = {
-		drone_job_check_trigger = yes
-	}
-
-	triggered_planet_modifier = {
-		potential = {
-			planet = { has_modifier = planet_artifact_relays_hivemind }
-		}
-		modifier = {
-			planet_stability_add = 2
-			planet_jobs_simple_drone_produces_mult = 0.01
-		}
-	}
-
-	resources = {
-		category = planet_jobs
-		produces = {
-			unity = 3
-			society_research = 3
-		}
-		upkeep = {
-			trigger = {
-				is_lithoid = no
-			}
-			food = 2
-			energy = 2
-		}
-		upkeep = {
-			trigger = {
-				is_lithoid = yes
-			}
-			minerals = 2
-			energy = 2
-		}
-	}
-	
-	weight = {
-		weight = @synapse_drone_job_weight
-		modifier = {
-			factor = 0.9
-			exists = owner
-			years_passed < 1
-			owner = { has_valid_civic = civic_machine_assimilator }
-			has_trait = trait_cybernetic
-		}		
+		weight = 50000
 	}
 }
 
@@ -750,115 +537,158 @@ brain_drone = {
 	}
 
 	possible = {
+		or = {
+			has_job = brain_drone
+			retile_job_seeking = yes
+		}
 		drone_job_check_trigger = yes
+		owner = { is_hive_empire = yes }
 	}
 
-	resources = {
-		category = planet_researchers
-		produces = {	
-			physics_research = 4
-			engineering_research = 4
-			society_research = 4
-		}
-		upkeep = {
-			minerals = 6
-		}		
-	}
+	############################################################ Brain Drone Production/Upkeep
 	
-	weight = {
-		weight = @complex_drone_job_weight
-		modifier = {
-			factor = 3
-			has_trait = trait_erudite
-		}
-		modifier = {
-			factor = 2
-			has_trait = trait_intelligent
-		}
-		modifier = {
-			factor = 1.5
-			OR = {
-				has_trait = trait_natural_engineers
-				has_trait = trait_natural_physicists
-				has_trait = trait_natural_sociologists
-			}
-		}	
-		modifier = {
-			factor = 0.65
-			OR = {
-				has_trait = trait_syncretic_proles
-				has_trait = trait_presapient_proles	
-			}
-		}
-		modifier = {
-			factor = 0.9
-			exists = owner
-			years_passed < 1
-			owner = { has_valid_civic = civic_machine_assimilator }
-			has_trait = trait_cybernetic
-		}		
-		modifier = {
-			factor = 0
-			planet = {
-				owner = {
-					is_ai = yes
-					has_resource = { type = minerals amount < 500 }
-				}
-			}
-		}
-	}
-}
-
-calculator = {
-	category = complex_drone
-	condition_string = DRONE_JOB_TRIGGER
-	building_icon = building_research_lab_1
-	
-	possible_pre_triggers = {
-		has_owner = yes
-		is_enslaved = no
-		is_being_purged = no
-		is_being_assimilated = no
-	}
-
-	possible = {
-		drone_job_check_trigger = yes
-	}
-
 	resources = {
 		category = planet_researchers
 		produces = {
-			physics_research = 4
-			engineering_research = 4
-			society_research = 4
+			physics_research = 2.5
+			engineering_research = 2.5
+			society_research = 2.5
+			unity = 2.5
 		}
 		upkeep = {
-			minerals = 6
+			consumer_goods = 2.5
+		}		
+		produces = {
+			trigger = { planet = { has_building = building_research_lab_1 } }
+			physics_research = 2.5
+			engineering_research = 2.5
+			society_research = 2.5
+		}
+		upkeep = {
+			trigger = { planet = { has_building = building_research_lab_1 } }
+			consumer_goods = 1.25
+		}		
+		produces = {
+			trigger = { planet = { has_building = building_research_lab_2 } }
+			physics_research = 5
+			engineering_research = 5
+			society_research = 5
+		}
+		upkeep = {
+			trigger = { planet = { has_building = building_research_lab_2 } }
+			consumer_goods = 2.5
+		}		
+		produces = {
+			trigger = { planet = { has_building = building_research_lab_3 } }
+			physics_research = 7.5
+			engineering_research = 7.5
+			society_research = 7.5
+		}
+		upkeep = {
+			trigger = { planet = { has_building = building_research_lab_3 } }
+			consumer_goods = 3.75
+		}		
+		produces = {
+			trigger = { planet = { has_building = building_institute } }
+			physics_research = 2.5
+			engineering_research = 2.5
+			society_research = 2.5
+		}
+		upkeep = {
+			trigger = { planet = { has_building = building_institute } }
+			consumer_goods = 1.25
+		}		
+		produces = {
+			trigger = { planet = { OR = {
+				has_building = building_hive_node
+				has_building = building_uplink_node
+			} } }
+			unity = 2.5
+		}
+		upkeep = {
+			trigger = { planet = { OR = {
+				has_building = building_hive_node
+				has_building = building_uplink_node
+			} } }
+			consumer_goods = 1.25
+		}		
+		produces = {
+			trigger = { planet = { OR = {
+				has_building = building_hive_cluster
+				has_building = building_network_junction
+			} } }
+			unity = 5
+		}
+		upkeep = {
+			trigger = { planet = { OR = {
+				has_building = building_hive_cluster
+				has_building = building_network_junction
+			} } }
+			consumer_goods = 2.5
+		}		
+		produces = {
+			trigger = { planet = { OR = {
+				has_building = building_hive_confluence
+				has_building = building_system_conflux
+			} } }
+			unity = 7.5
+		}
+		upkeep = {
+			trigger = { planet = { OR = {
+				has_building = building_hive_confluence
+				has_building = building_system_conflux
+			} } }
+			consumer_goods = 3.75
 		}		
 	}
+
+	############################################################ Brain Drone Pollution
+	
+	planet_modifier = {
+		planet_amenities_no_happiness_add = 15
+	}
+	triggered_planet_modifier = {
+		potential = { planet = { has_building = building_research_lab_1 } }
+		modifier = { planet_amenities_no_happiness_add = 7.5 }
+	}
+	triggered_planet_modifier = {
+		potential = { planet = { has_building = building_research_lab_2 } }
+		modifier = { planet_amenities_no_happiness_add = 15 }
+	}
+	triggered_planet_modifier = {
+		potential = { planet = { has_building = building_research_lab_3 } }
+		modifier = { planet_amenities_no_happiness_add = 22.5 }
+	}
+	triggered_planet_modifier = {
+		potential = { planet = { has_building = building_institute } }
+		modifier = { planet_amenities_no_happiness_add = 7.5 }
+	}
+	triggered_planet_modifier = {
+		potential = { planet = { OR = {
+			has_building = building_hive_node
+			has_building = building_uplink_node
+		} } }
+		modifier = { planet_amenities_no_happiness_add = 7.5 }
+	}
+	triggered_planet_modifier = {
+		potential = { planet = { OR = {
+			has_building = building_hive_cluster
+			has_building = building_network_junction
+		} } }
+		modifier = { planet_amenities_no_happiness_add = 15 }
+	}
+	triggered_planet_modifier = {
+		potential = { planet = { OR = {
+			has_building = building_hive_confluence
+			has_building = building_system_conflux
+		} } }
+		modifier = { planet_amenities_no_happiness_add = 22.5 }
+	}
+	
+	############################################################ Brain Drone Job Weight
 	
 	weight = {
-		weight = @complex_drone_job_weight
-		modifier = {
-			factor = 2
-			has_trait = trait_robot_logic_engines
-		}
-		modifier = {
-			factor = 0.9
-			exists = owner
-			years_passed < 1
-			owner = { has_valid_civic = civic_machine_assimilator }
-			has_trait = trait_cybernetic
-		}		
-		modifier = {
-			factor = 0
-			planet = {
-				owner = {
-					is_ai = yes
-					has_resource = { type = minerals amount < 500 }
-				}
-			}
-		}
+		weight = 20
 	}
 }
 
@@ -876,222 +706,121 @@ artisan_drone = {
 
 	possible = {
 		drone_job_check_trigger = yes
+		or = {
+			has_job = artisan_drone
+			retile_job_seeking = yes
+		}
+		owner = { is_hive_empire = yes }
 	}
 	
-	resources = {
-		category = planet_artisans
-		produces = {
-			consumer_goods = 8
-		}		
-		upkeep = {
-			minerals = 8
-		}
-	}	
+	############################################################ Factory Drone Production/Upkeep
 	
-	weight = {
-		weight = 5000
-		modifier = {
-			factor = 0.9
-			exists = owner
-			years_passed < 1
-			owner = { has_valid_civic = civic_machine_assimilator }
-			has_trait = trait_cybernetic
-		}
-		modifier = {
-			factor = 0
-			jobs_work_minerals_goods = yes
-		}
-	}
-}
-
-fabricator = {
-	category = complex_drone
-	condition_string = DRONE_JOB_TRIGGER
-	building_icon = building_foundry_1
-	
-	possible_pre_triggers = {
-		has_owner = yes
-		is_enslaved = no
-		is_being_purged = no
-		is_being_assimilated = no
-	}
-
-	possible = {
-		drone_job_check_trigger = yes
-	}
-
 	resources = {
 		category = planet_metallurgists
 		produces = {
-			alloys = 4
+			consumer_goods = 2.5
+			alloys = 2.5
 		}
-		upkeep = {
-			minerals = 8
-		}
-	}
-	
-	weight = {
-		weight = @complex_drone_job_weight
-		modifier = {
-			factor = 0.9
-			exists = owner
-			years_passed < 1
-			owner = { has_valid_civic = civic_machine_assimilator }
-			has_trait = trait_cybernetic
-		}
-		modifier = {
-			factor = 0
-			jobs_work_minerals = yes
-		}
-	}
-}
-
-alloy_drone = {
-	category = complex_drone
-	condition_string = DRONE_JOB_TRIGGER
-	building_icon = building_foundry_1
-	
-	possible_pre_triggers = {
-		has_owner = yes
-		is_enslaved = no
-		is_being_purged = no
-		is_being_assimilated = no
-	}
-
-	possible = {
-		drone_job_check_trigger = yes
-	}
-
-	resources = {
-		category = planet_metallurgists
-		produces = {
-			alloys = 3
-		}
-		upkeep = {
-			minerals = 6
-		}
-	}
-	
-	weight = {
-		weight = @complex_drone_job_weight
-		modifier = {
-			factor = 0
-			jobs_work_minerals = yes
-		}
-	}
-}
-
-chemist_drone = {
-	category = complex_drone
-	condition_string = DRONE_JOB_TRIGGER
-	building_icon = building_chemical_plant
-	
-	possible_pre_triggers = {
-		has_owner = yes
-		is_enslaved = no
-		is_being_purged = no
-		is_being_assimilated = no
-	}
-
-	possible = {
-		drone_job_check_trigger = yes
-	}
-	
-	resources = {
-		category = planet_chemists
-		produces = {
-			volatile_motes = 2
-		}		
-		upkeep = {
-			minerals = 10
-		}	
-	}
-	
-	weight = {
-		weight = @complex_drone_job_weight
-		modifier = {
-			factor = 0.9
-			exists = owner
-			years_passed < 1
-			owner = { has_valid_civic = civic_machine_assimilator }
-			has_trait = trait_cybernetic
-		}
-	}
-}
-
-translucer_drone = {
-	category = complex_drone
-	condition_string = DRONE_JOB_TRIGGER
-	building_icon = building_crystal_plant
-	
-	possible_pre_triggers = {
-		has_owner = yes
-		is_enslaved = no
-		is_being_purged = no
-		is_being_assimilated = no
-	}
-
-	possible = {
-		drone_job_check_trigger = yes
-	}
-
-	resources = {
-		category = planet_translucers
-		produces = {
-			rare_crystals = 2
-		}		
-		upkeep = {
-			minerals = 10
-		}	
-	}
-	
-	weight = {
-		weight = @complex_drone_job_weight
-		modifier = {
-			factor = 0.9
-			exists = owner
-			years_passed < 1
-			owner = { has_valid_civic = civic_machine_assimilator }
-			has_trait = trait_cybernetic
-		}
-	}
-}
-
-gas_refiner_drone = {
-	category = complex_drone
-	condition_string = DRONE_JOB_TRIGGER
-	building_icon = building_refinery
-	
-	possible_pre_triggers = {
-		has_owner = yes
-		is_enslaved = no
-		is_being_purged = no
-		is_being_assimilated = no
-	}
-
-	possible = {
-		drone_job_check_trigger = yes
-	}
-
-	resources = {
-		category = planet_refiners
-		produces = {
-			exotic_gases = 2
-		}		
 		upkeep = {
 			minerals = 10
 		}
-	}
-	
-	weight = {
-		weight = @complex_drone_job_weight
-		modifier = {
-			factor = 0.9
-			exists = owner
-			years_passed < 1
-			owner = { has_valid_civic = civic_machine_assimilator }
-			has_trait = trait_cybernetic
+		produces = {
+			trigger = { planet = { has_building = building_factory_1 } }
+			consumer_goods = 2.5
 		}
+		upkeep = {
+			trigger = { planet = { has_building = building_factory_1 } }
+			minerals = 5
+		}
+		produces = {
+			trigger = { planet = { has_building = building_factory_2 } }
+			consumer_goods = 5
+		}
+		upkeep = {
+			trigger = { planet = { has_building = building_factory_2 } }
+			minerals = 10
+		}
+		produces = {
+			trigger = { planet = { has_building = building_factory_3 } }
+			consumer_goods = 7.5
+		}
+		upkeep = {
+			trigger = { planet = { has_building = building_factory_3 } }
+			minerals = 15
+		}
+		produces = {
+			trigger = { planet = { has_building = building_foundry_1 } }
+			alloys = 2.5
+		}
+		upkeep = {
+			trigger = { planet = { has_building = building_foundry_1 } }
+			minerals = 5
+		}
+		produces = {
+			trigger = { planet = { has_building = building_foundry_2 } }
+			alloys = 5
+		}
+		upkeep = {
+			trigger = { planet = { has_building = building_foundry_2 } }
+			minerals = 10
+		}
+		produces = {
+			trigger = { planet = { has_building = building_foundry_3 } }
+			alloys = 7.5
+		}
+		upkeep = {
+			trigger = { planet = { has_building = building_foundry_3 } }
+			minerals = 15
+		}
+		produces = {
+			trigger = { planet = { has_building = building_ministry_production } }
+			alloys = 2.5
+			consumer_goods = 2.5
+		}
+		upkeep = {
+			trigger = { planet = { has_building = building_ministry_production } }
+			minerals = 10
+		}
+	}
+
+	############################################################ Engineer Pollution
+	
+	planet_modifier = {
+		planet_amenities_no_happiness_add = 30
+	}
+	triggered_planet_modifier = {
+		potential = { planet = { has_building = building_factory_1 } }
+		modifier = { planet_amenities_no_happiness_add = 15 }
+	}
+	triggered_planet_modifier = {
+		potential = { planet = { has_building = building_factory_2 } }
+		modifier = { planet_amenities_no_happiness_add = 30 }
+	}
+	triggered_planet_modifier = {
+		potential = { planet = { has_building = building_factory_3 } }
+		modifier = { planet_amenities_no_happiness_add = 45 }
+	}
+	triggered_planet_modifier = {
+		potential = { planet = { has_building = building_foundry_1 } }
+		modifier = { planet_amenities_no_happiness_add = 15 }
+	}
+	triggered_planet_modifier = {
+		potential = { planet = { has_building = building_foundry_2 } }
+		modifier = { planet_amenities_no_happiness_add = 30 }
+	}
+	triggered_planet_modifier = {
+		potential = { planet = { has_building = building_foundry_3 } }
+		modifier = { planet_amenities_no_happiness_add = 45 }
+	}
+	triggered_planet_modifier = {
+		potential = { planet = { has_building = building_ministry_production } }
+		modifier = { planet_amenities_no_happiness_add = 30 }
+	}
+
+	############################################################ Engineer Job Weight
+
+	weight = {
+		weight = 20
 	}
 }
 
@@ -1109,164 +838,175 @@ patrol_drone = {
 
 	possible = {
 		drone_job_check_trigger = yes
+		or = {
+			has_job = patrol_drone
+			retile_job_seeking = yes
+		}
+		owner = { is_hive_empire = yes }
 	}
 	
-	resources = {
-		category = planet_jobs
-		produces = {
-			unity = 1
-		}	
+	pop_modifier = {
+		pop_defense_armies_add = 6
 	}
 	
 	planet_modifier = {
-		planet_crime_no_happiness_add = -20
-	}	
+		planet_crime_add = -25
+		planet_amenities_no_happiness_add = 25
+	}
 
+	triggered_planet_modifier = {
+		potential = {
+			exists = owner
+			owner = { has_civic = civic_police_state }
+		}
+		modifier = {
+			planet_stability_add = 1
+		}		
+	}
+	
+	triggered_pop_modifier = {
+		potential = {
+			exists = owner
+			owner = { has_policy_flag = criminal_common_law }
+		}
+		pop_defense_armies_add = -4
+	}
+	
+	triggered_planet_modifier = {
+		potential = {
+			exists = owner
+			owner = { has_ascension_perk = ap_mind_over_matter }
+		}
+		modifier = {
+			planet_crime_add = -10
+			planet_amenities_no_happiness_add = 10
+			planet_stability_add = 2
+		}		
+	}
+
+	weight = {
+		weight = 20
+	}
+}
+
+warrior_drone = {
+	category = complex_drone
+	condition_string = DRONE_JOB_TRIGGER
+	building_icon = building_stronghold
+	
+	possible_pre_triggers = {
+		has_owner = yes
+		is_enslaved = no
+		is_being_purged = no
+		is_being_assimilated = no
+	}
+
+	possible = {
+		drone_job_check_trigger = yes
+		or = {
+			has_job = warrior_drone
+			retile_job_seeking = yes
+		}
+		owner = { is_hive_empire = yes }
+	}
+	
 	pop_modifier = {
+		pop_defense_armies_add = 6
+	}
+	
+	country_modifier = {
+		country_naval_cap_add = 10
+	}
+	planet_modifier = {
+		planet_amenities_no_happiness_add = 20
+	}
+	
+	triggered_planet_modifier = {
+		potential = {
+			exists = owner
+			owner = { has_policy_flag = criminal_military_police }
+		}
+		planet_crime_add = -15
+		planet_amenities_no_happiness_add = 25
+	}
+	
+	triggered_planet_modifier = {
+		potential = {
+			exists = owner
+			owner = { has_civic = civic_citizen_service }
+		}
+		modifier = {
+			planet_stability_add = 1
+		}		
+	}
+
+	triggered_country_modifier = {
+		potential = {
+			exists = owner 
+			owner = { has_technology = "tech_ground_defense_planning" }
+		}
+		modifier = {
+			country_naval_cap_add = 5
+		}
+	}
+	triggered_planet_modifier = {
+		potential = {
+			exists = owner
+			owner = { has_technology = "tech_ground_defense_planning" }
+		}
+		modifier = {
+			planet_amenities_no_happiness_add = 10
+		}
+	}
+
+	triggered_country_modifier = {
+		potential = {
+			exists = owner 
+			owner = { has_technology = "tech_global_defense_grid" }
+		}
+		modifier = {
+			country_naval_cap_add = 5
+		}
+	}
+	triggered_planet_modifier = {
+		potential = {
+			exists = owner
+			owner = { has_technology = "tech_global_defense_grid" }
+		}
+		modifier = {
+			planet_amenities_no_happiness_add = 10
+		}
+	}
+	triggered_pop_modifier = {
+		potential = {
+			exists = owner
+			owner = { has_technology = tech_global_defense_grid }
+		}
 		pop_defense_armies_add = 2
 	}
-		
-	weight = {
-		weight = @complex_drone_job_weight
-		modifier = {
-			factor = 50
-			planet = { planet_crime > 22 }
-		}
-		modifier = {
-			weight = 20
-			exists = owner
-			owner = { is_at_war = yes }
-		}
-		modifier = {
-			factor = 3
-			has_trait = trait_resilient
-		}
-		modifier = {
-			factor = 3
-			has_trait = trait_very_strong
-		}
-		modifier = {
-			factor = 2
-			has_trait = trait_strong
-		}
-		modifier = {
-			factor = 0.5
-			has_trait = trait_weak
-		}
-	}
-}
-
-crystal_mining_drone = {	
-	category = complex_drone
-	condition_string = DRONE_JOB_TRIGGER
-	building_icon = building_crystal_mines
 	
-	possible_pre_triggers = {
-		has_owner = yes
-		is_enslaved = no
-		is_being_purged = no
-		is_being_assimilated = no
-	}
-
-	possible = {
-		drone_job_check_trigger = yes
-	}
-
-	resources = {
-		category = planet_jobs
-		produces = {
-			rare_crystals = 2
-		}
-		upkeep = {
-			energy = 1
-		}
-	}	
-	
-	weight = {
-		weight = @complex_drone_job_weight
-		modifier = {
-			factor = 1.1
+	triggered_country_modifier = {
+		potential = {
 			exists = owner
-			years_passed < 1
-			owner = { has_valid_civic = civic_machine_assimilator }
-			has_trait = trait_cybernetic
+			owner = { has_ascension_perk = ap_mind_over_matter }
+		}
+		modifier = {
+			country_naval_cap_add = 5
 		}		
 	}
-}
-
-mote_harvesting_drone = {	
-	category = complex_drone
-	condition_string = DRONE_JOB_TRIGGER
-	building_icon = building_mote_harvesters
-	
-	possible_pre_triggers = {
-		has_owner = yes
-		is_enslaved = no
-		is_being_purged = no
-		is_being_assimilated = no
-	}
-
-	possible = {
-		drone_job_check_trigger = yes
-	}
-
-	resources = {
-		category = planet_jobs
-		produces = {
-			volatile_motes = 2
-		}
-		upkeep = {
-			energy = 1
-		}		
-	}	
-	
-	weight = {
-		weight = @complex_drone_job_weight
-		modifier = {
-			factor = 1.1
+	triggered_planet_modifier = {
+		potential = {
 			exists = owner
-			years_passed < 1
-			owner = { has_valid_civic = civic_machine_assimilator }
-			has_trait = trait_cybernetic
-		}			
-	}
-}
-
-gas_extraction_drone = {	
-	category = complex_drone
-	condition_string = DRONE_JOB_TRIGGER
-	building_icon = building_gas_extractors
-	
-	possible_pre_triggers = {
-		has_owner = yes
-		is_enslaved = no
-		is_being_purged = no
-		is_being_assimilated = no
-	}
-
-	possible = {
-		drone_job_check_trigger = yes
-	}
-
-	resources = {
-		category = planet_jobs
-		produces = {
-			exotic_gases = 2
+			owner = { has_ascension_perk = ap_mind_over_matter }
 		}
-		upkeep = {
-			energy = 1
-		}		
-	}	
-	
-	weight = {
-		weight = @complex_drone_job_weight
 		modifier = {
-			factor = 1.1
-			exists = owner
-			years_passed < 1
-			owner = { has_valid_civic = civic_machine_assimilator }
-			has_trait = trait_cybernetic
-		}			
+			planet_amenities_no_happiness_add = 10
+			planet_stability_add = 2
+		}		
+	}
+
+	weight = {
+		weight = 20
 	}
 }
 
@@ -1284,45 +1024,57 @@ mining_drone = {
 
 	possible = {
 		drone_job_check_trigger = yes
+		or = {
+			has_job = mining_drone
+			retile_job_seeking = yes
+		}
+		owner = { is_hive_empire = yes }
 	}
 
 	resources = {
 		category = planet_miners
 		produces = {
-			minerals = 4
-		}	
-	}
+			minerals = 10
+		}
+		produces = {
+			trigger = { planet = { has_building = building_mineral_purification_plant } }
+			minerals = 10
+		}
+		produces = {
+			trigger = { planet = { has_building = building_mineral_purification_hub } }
+			minerals = 20
+		}
+		produces = {
+			trigger = { owner = { has_civic = civic_mining_guilds } }
+			unity = 3
+		}
+	}	
 	
-	weight = {
-		weight = @simple_drone_job_weight
-		modifier = {
-			factor = 2
-			OR = {
-				has_trait = trait_industrious
-				has_trait = trait_robot_power_drills
-			}		
-		}
-		modifier = {
-			factor = 1.1
+	planet_modifier = {
+		planet_amenities_no_happiness_add = 30
+	}
+	triggered_planet_modifier = {
+		potential = { planet = { has_building = building_mineral_purification_plant } }
+		modifier = { planet_amenities_no_happiness_add = 30 }
+	}
+	triggered_planet_modifier = {
+		potential = { planet = { has_building = building_mineral_purification_hub } }
+		modifier = { planet_amenities_no_happiness_add = 60 }
+	}
+
+
+	triggered_pop_modifier = {
+		potential = {
 			exists = owner
-			years_passed < 1
-			owner = { has_valid_civic = civic_machine_assimilator }
-			has_trait = trait_cybernetic
+			owner = { has_civic = civic_warrior_culture }
 		}
 		modifier = {
-			factor = 1.2
-			has_job = mining_drone
-		}
-		modifier = {
-			factor = 0.9
-			NOT = { has_job = mining_drone }
-			owner = {
-				has_monthly_income = {
-					resource = minerals
-					value > 85
-				}
-			}
-		}
+			pop_defense_armies_add = 2
+		}		
+	}
+
+	weight = {
+		weight = 10
 	}
 }
 
@@ -1340,59 +1092,56 @@ agri_drone = {
 
 	possible = {
 		drone_job_check_trigger = yes
+		or = {
+			has_job = agri_drone
+			retile_job_seeking = yes
+		}
+		owner = { is_hive_empire = yes }
 	}
 
 	resources = {
 		category = planet_farmers
 		produces = {
-			food = 6
+			food = 4
 		}
 		produces = {
-			trigger = { 
-				owner = {
-					is_robot_empire = yes
-				}
-			}
-			food = -1
+			trigger = { planet = { has_building = building_food_processing_facility } }
+			food = 4
 		}
-	}
+		produces = {
+			trigger = { planet = { has_building = building_food_processing_center } }
+			food = 8
+		}
+		produces = {
+			trigger = { owner = { has_civic = civic_agrarian_idyll } }
+			unity = 3
+		}
+	}	
 	
-	weight = {
-		weight = @simple_drone_job_weight
-		modifier = {
-			factor = 2
-			OR = {
-				has_trait = trait_agrarian
-				has_trait = trait_robot_harvesters
-			}		
-		}
-		modifier = {
-			factor = 0.9
-			NOT = { has_job = mining_drone }
-			owner = {
-				has_monthly_income = {
-					resource = food
-					value > 50
-				}
-			}
-		}
-		modifier = {
-			factor = 1.2
-			has_job = agri_drone
-		}
-		modifier = {
-			factor = 0.9
-			owner = {
-				is_robot_empire = yes
-			}
-		}	
-		modifier = {
-			factor = 1.1
+	planet_modifier = {
+		planet_amenities_no_happiness_add = 30
+	}
+	triggered_planet_modifier = {
+		potential = { planet = { has_building = building_food_processing_facility } }
+		modifier = { planet_amenities_no_happiness_add = 30 }
+	}
+	triggered_planet_modifier = {
+		potential = { planet = { has_building = building_food_processing_center } }
+		modifier = { planet_amenities_no_happiness_add = 60 }
+	}
+
+	triggered_pop_modifier = {
+		potential = {
 			exists = owner
-			years_passed < 1
-			owner = { has_valid_civic = civic_machine_assimilator }
-			has_trait = trait_cybernetic
+			owner = { has_civic = civic_warrior_culture }
+		}
+		modifier = {
+			pop_defense_armies_add = 2
 		}		
+	}
+
+	weight = {
+		weight = 10		
 	}
 }
 
@@ -1410,53 +1159,52 @@ technician_drone = {
 
 	possible = {
 		drone_job_check_trigger = yes
+		or = {
+			has_job = technician_drone
+			retile_job_seeking = yes
+		}
+		owner = { is_hive_empire = yes }
 	}
 
 	resources = {
 		category = planet_technician
 		produces = {
-			energy = 4
+			energy = 10
 		}
 		produces = {
-			trigger = { 
-				owner = {
-					is_robot_empire = yes
-				}
-			}
-			energy = 2
+			trigger = { planet = { has_building = building_energy_grid } }
+			energy = 10
+		}
+		produces = {
+			trigger = { planet = { has_building = building_energy_nexus } }
+			energy = 20
 		}
 	}
-	
-	weight = {
-		weight = @simple_drone_job_weight
-		modifier = {
-			factor = 2
-			OR = {
-				has_trait = trait_robot_superconductive
-				has_trait = trait_ingenious
-			}		
-		}
-		modifier = {
-			factor = 0.9
-			NOT = { has_job = mining_drone }
-			owner = {
-				has_monthly_income = {
-					resource = energy
-					value > 50
-				}
-			}
-		}
-		modifier = {
-			factor = 1.2
-			has_job = technician_drone
-		}
-		modifier = {
-			factor = 1.1
+
+	planet_modifier = {
+		planet_amenities_no_happiness_add = 30
+	}
+	triggered_planet_modifier = {
+		potential = { planet = { has_building = building_energy_grid } }
+		modifier = { planet_amenities_no_happiness_add = 30 }
+	}
+	triggered_planet_modifier = {
+		potential = { planet = { has_building = building_energy_nexus } }
+		modifier = { planet_amenities_no_happiness_add = 60 }
+	}
+
+	triggered_pop_modifier = {
+		potential = {
 			exists = owner
-			years_passed < 1
-			owner = { has_valid_civic = civic_machine_assimilator }
-			has_trait = trait_cybernetic
+			owner = { has_civic = civic_warrior_culture }
+		}
+		modifier = {
+			pop_defense_armies_add = 2
 		}		
+	}
+
+	weight = {
+		weight = 10	
 	}
 }
 
@@ -1474,168 +1222,151 @@ maintenance_drone = {
 
 	possible = {
 		drone_job_check_trigger = yes
+		or = {
+			has_job = maintenance_drone
+			retile_job_seeking = yes
+		}
+		owner = { is_hive_empire = yes }
 	}
 	
 	planet_modifier = {
-		planet_amenities_no_happiness_add = 4
+		planet_amenities_no_happiness_add = -50
 	}
 	triggered_planet_modifier = {
-		potential = {
-			OR = {
-				has_trait = trait_robot_emotion_emulators
-				has_trait = trait_charismatic
-			}
-		}
-		modifier = {
-			planet_amenities_no_happiness_add = 1
-		}
+		potential = { planet = { has_deposit = retile_deposit_waste_reprocessing } }
+		modifier = { planet_amenities_no_happiness_add = -50 }
 	}
 	triggered_planet_modifier = {
-		potential = {
-			OR = {
-				has_trait = trait_robot_uncanny
-				has_trait = trait_repugnant
-			}
-		}
-		modifier = {
-			planet_amenities_no_happiness_add = 1
-		}
-	}		
-	
-	weight = {
-		weight = 1
-		modifier = {
-			weight = 200
-			OR = {
-				planet = { free_amenities < 7 }
-			has_job = maintenance_drone
-			}
-		}
-		modifier = {
-			factor = 2
-			OR = {
-				has_trait = trait_robot_emotion_emulators
-				has_trait = trait_charismatic
-			}
-		}
-		modifier = {
-			factor = 0.5
-			OR = {
-				has_trait = trait_robot_uncanny
-				has_trait = trait_repugnant
-			}
-		}
-		modifier = {
-			factor = 1.1
-			exists = owner
-			years_passed < 1
-			owner = { has_valid_civic = civic_machine_assimilator }
-			has_trait = trait_cybernetic
-		}
-		modifier = {
-			factor = 0.1
-			NOT = { has_job = maintenance_drone }
-			planet = {
-				free_amenities > 5
-			}
-		}		
+		potential = { planet = { has_building = building_maintenance_depot } }
+		modifier = { planet_amenities_no_happiness_add = -50 }
 	}
-}
-
-warrior_drone = {
-	category = simple_drone
-	condition_string = DRONE_JOB_TRIGGER
-	building_icon = building_stronghold
-	
-	country_modifier = {
-		country_naval_cap_add = 4
+	triggered_planet_modifier = {
+		potential = { planet = {
+			has_building = building_maintenance_depot
+			has_deposit = retile_deposit_waste_reprocessing
+		} }
+		modifier = { planet_amenities_no_happiness_add = -50 }
+	}
+	triggered_planet_modifier = {
+		potential = { planet = { has_building = building_maintenance_depot_2 } }
+		modifier = { planet_amenities_no_happiness_add = -100 }
+	}
+	triggered_planet_modifier = {
+		potential = { planet = {
+			has_building = building_maintenance_depot_2
+			has_deposit = retile_deposit_waste_reprocessing
+		} }
+		modifier = { planet_amenities_no_happiness_add = -100 }
 	}
 	
-	triggered_country_modifier = {
-		potential = {
-			planet = {
-				exists = owner 
-				owner = { has_technology = "tech_ground_defense_planning" }
-			}
+	resources = {
+		category = planet_custodians
+		produces = {
+			society_research = 2.5
 		}
-		modifier = {
-			country_naval_cap_add = 2
+		produces = {
+			trigger = { planet = { has_building = building_maintenance_depot } }
+			society_research = 2.5
 		}
-	}
-	
-	pop_modifier = {
-		pop_defense_armies_add = 3
+		produces = {
+			trigger = { planet = {
+				has_building = building_maintenance_depot
+				has_deposit = retile_deposit_waste_reprocessing
+			} }
+			society_research = 2.5
+		}
+		produces = {
+			trigger = { planet = { has_building = building_maintenance_depot_2 } }
+			society_research = 5
+		}
+		produces = {
+			trigger = { planet = {
+				has_building = building_maintenance_depot_2
+				has_deposit = retile_deposit_waste_reprocessing
+			} }
+			society_research = 2.5
+		}
+		produces = {
+			trigger = { planet = { has_building = building_solar_panels } }
+			energy = 10
+		}
+		produces = {
+			trigger = { planet = { has_building = building_recycling_center } }
+			minerals = 10
+		}
+		produces = {
+			trigger = { planet = { has_building = building_hydroponics_farm } }
+			food = 4
+		}
+		produces = {
+			trigger = { planet = {
+				has_building = building_solar_panels
+				has_deposit = retile_deposit_waste_reprocessing
+			} }
+			energy = 10
+		}
+		produces = {
+			trigger = { planet = {
+				has_building = building_recycling_center
+				has_deposit = retile_deposit_waste_reprocessing
+			} }
+			minerals = 10
+		}
+		produces = {
+			trigger = { planet = {
+				has_building = building_hydroponics_farm
+				has_deposit = retile_deposit_waste_reprocessing
+			} }
+			food = 4
+		}
 	}
 	
 	triggered_planet_modifier = {
-		potential = {
-			planet = {
-				OR = {
-					has_modifier = compliance_protocols
-					has_modifier = hunter_killer_drones
-				}			
-			}
-		}
-		modifier = {
-			planet_stability_add = 5
-		}
+		potential = { planet = { has_building = building_solar_panels } }
+		modifier = { planet_amenities_no_happiness_add = 30 }
 	}
-	
-	possible_pre_triggers = {
-		has_owner = yes
-		is_enslaved = no
-		is_being_purged = no
-		is_being_assimilated = no
+	triggered_planet_modifier = {
+		potential = { planet = { has_building = building_recycling_center } }
+		modifier = { planet_amenities_no_happiness_add = 30 }
+	}
+	triggered_planet_modifier = {
+		potential = { planet = { has_building = building_hydroponics_farm } }
+		modifier = { planet_amenities_no_happiness_add = 30 }
 	}
 
-	possible = {
-		drone_job_check_trigger = yes
+	triggered_planet_modifier = {
+		potential = { planet = {
+			has_building = building_solar_panels
+			has_deposit = retile_deposit_waste_reprocessing
+		} }
+		modifier = { planet_amenities_no_happiness_add = 30 }
 	}
-	
+	triggered_planet_modifier = {
+		potential = { planet = {
+			has_building = building_recycling_center
+			has_deposit = retile_deposit_waste_reprocessing
+		} }
+		modifier = { planet_amenities_no_happiness_add = 30 }
+	}
+	triggered_planet_modifier = {
+		potential = { planet = {
+			has_building = building_hydroponics_farm
+			has_deposit = retile_deposit_waste_reprocessing
+		} }
+		modifier = { planet_amenities_no_happiness_add = 30 }
+	}
+
+	triggered_pop_modifier = {
+		potential = {
+			exists = owner
+			owner = { has_civic = civic_warrior_culture }
+		}
+		modifier = {
+			pop_defense_armies_add = 2
+		}
+	}
+
 	weight = {
-		weight = 5
-		modifier = {
-			weight = 100
-			exists = owner
-			owner = { is_at_war = yes }
-		}
-		modifier = {
-			factor = 10
-			planet = {
-				OR = {
-					has_modifier = compliance_protocols
-					has_modifier = hunter_killer_drones
-				}
-			}
-		}
-		modifier = {
-			factor = 4
-			has_trait = trait_resilient
-		}	
-		modifier = {
-			factor = 4
-			has_trait = trait_very_strong
-		}	
-		modifier = {
-			factor = 3
-			has_trait = trait_strong
-		}	
-		modifier = {
-			factor = 0.5
-			has_trait = trait_weak
-		}	
-		modifier = {
-			factor = 0.9
-			exists = owner
-			years_passed < 1
-			owner = { has_valid_civic = civic_machine_assimilator }
-			has_trait = trait_cybernetic
-		}
-		modifier = {
-			weight = 0
-			factor = 0
-			planet = { count_pops = { limit = { } count < 12 } }
-			owner = { is_ai = yes }
-		}		
+		weight = 10	
 	}
 }

--- a/common/pop_jobs/04_gestalt_jobs.txt
+++ b/common/pop_jobs/04_gestalt_jobs.txt
@@ -1,5 +1,8 @@
+###################
+# Gestalt Jobs
+###################
 spawning_drone = {
-	category = breeding_drone
+	category = complex_drone
 	condition_string = DRONE_JOB_TRIGGER
 	building_icon = building_spawning_pool
 		
@@ -11,38 +14,726 @@ spawning_drone = {
 	}
 
 	possible = {
-		or = {
-			has_job = spawning_drone
-			retile_job_seeking = yes
-		}
 		drone_job_check_trigger = yes
-		owner = { is_hive_empire = yes }
 	}
 	
 	planet_modifier = {
-		planet_amenities_no_happiness_add = 50
-		pop_growth_speed = 0.50
-		planet_stability_add = 5
+		planet_amenities_no_happiness_add = 5
+		pop_growth_speed = 0.25
+	}
+	triggered_planet_modifier = {
+		potential = {
+			has_trait = trait_charismatic
+		}
+		modifier = {
+			planet_amenities_no_happiness_add = 1
+		}
+	}
+	triggered_planet_modifier = {
+		potential = {
+			has_trait = trait_repugnant
+		}
+		modifier = {
+			planet_amenities_no_happiness_add = -1
+		}
+	}	
+	
+	resources = {
+		category = planet_jobs
+
+		### ORGANIC UPKEEP ###
+		### should based on growth malus level
+		### every level of food upkeep is 5 * (1 - growth malus effect)
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
+				owner = { check_variable = { which = col_count value < 1 } }
+			}
+			food = 5
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_2 }
+			}
+			food = 4.5
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_3 }
+			}
+			food = 4.05
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_4 }
+			}
+			food = 3.7
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_5 }
+			}
+			food = 3.35
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_6 }
+			}
+			food = 3.05
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_7 }
+			}
+			food = 2.85
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_8 }
+			}
+			food = 2.6
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_9 }
+			}
+			food = 2.4
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_10 }
+			}
+			food = 2.25
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_11 }
+			}
+			food = 2.1
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_12 }
+			}
+			food = 1.95
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_13 }
+			}
+			food = 1.8
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_14 }
+			}
+			food = 1.7
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_15 }
+			}
+			food = 1.6
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_16 }
+			}
+			food = 1.5
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_17 }
+			}
+			food = 1.4
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_18 }
+			}
+			food = 1.35
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_19 }
+			}
+			food = 1.3
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_20 }
+			}
+			food = 1.25
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_21 }
+			}
+			food = 1.2
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_22 }
+			}
+			food = 1.15
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_23 }
+			}
+			food = 1.1
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_24 }
+			}
+			food = 1.05
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_25 }
+			}
+			food = 1.0
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_26 }
+			}
+			food = 0.95
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_27 }
+			}
+			food = 0.9
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_28 }
+			}
+			food = 0.85
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_29 }
+			}
+			food = 0.8
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = no
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_30 }
+			}
+			food = 0.75
+		}
+		### END ORGANIC UPKEEP ###
+
+		### LITHOID UPKEEP ###
+		### should based on growth malus level
+		### every level of minerals upkeep is 5 * (1 - growth malus effect)
+		upkeep = {
+			trigger = {
+				is_lithoid = yes
+				planet = { free_housing >= 0 }
+				owner = { check_variable = { which = col_count value < 1 } }
+			}
+			minerals = 5
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = yes
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_2 }
+			}
+			minerals = 4.5
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = yes
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_3 }
+			}
+			minerals = 4.05
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = yes
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_4 }
+			}
+			minerals = 3.7
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = yes
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_5 }
+			}
+			minerals = 3.35
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = yes
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_6 }
+			}
+			minerals = 3.05
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = yes
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_7 }
+			}
+			minerals = 2.85
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = yes
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_8 }
+			}
+			minerals = 2.6
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = yes
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_9 }
+			}
+			minerals = 2.4
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = yes
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_10 }
+			}
+			minerals = 2.25
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = yes
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_11 }
+			}
+			minerals = 2.1
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = yes
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_12 }
+			}
+			minerals = 1.95
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = yes
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_13 }
+			}
+			minerals = 1.8
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = yes
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_14 }
+			}
+			minerals = 1.7
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = yes
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_15 }
+			}
+			minerals = 1.6
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = yes
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_16 }
+			}
+			minerals = 1.5
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = yes
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_17 }
+			}
+			minerals = 1.4
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = yes
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_18 }
+			}
+			minerals = 1.35
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = yes
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_19 }
+			}
+			minerals = 1.3
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = yes
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_20 }
+			}
+			minerals = 1.25
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = yes
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_21 }
+			}
+			minerals = 1.2
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = yes
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_22 }
+			}
+			minerals = 1.15
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = yes
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_23 }
+			}
+			minerals = 1.1
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = yes
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_24 }
+			}
+			minerals = 1.05
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = yes
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_25 }
+			}
+			minerals = 1.0
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = yes
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_26 }
+			}
+			minerals = 0.95
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = yes
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_27 }
+			}
+			minerals = 0.9
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = yes
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_28 }
+			}
+			minerals = 0.85
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = yes
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_29 }
+			}
+			minerals = 0.8
+		}
+		upkeep = {
+			trigger = {
+				is_lithoid = yes
+				planet = { free_housing >= 0 }
+				owner = { has_modifier = retile_growth_malus_30 }
+			}
+			minerals = 0.75
+		}
+		### END LITHOID UPKEEP ###
+	}
+	
+	weight = {
+		weight = @spawner_drone_job_weight
+		modifier = {
+			factor = 1.25
+			has_trait = trait_charismatic
+		}
+		modifier = {
+			factor = 0.9
+			has_trait = trait_repugnant
+		}	
+		modifier = {
+			factor = 0.5 # job is less useful if pop control is active, but still gives amenities 
+			planet = {
+				has_modifier = planet_population_control_gestalt
+			}
+		}
+		modifier = {
+			factor = 0.01 # crisis purge
+			planet.controller = {
+				OR = {
+					is_country_type = swarm
+					is_country_type = ai_empire
+				}
+			}
+		}
+	}
+}
+
+replicator = {
+	category = complex_drone
+	condition_string = DRONE_JOB_TRIGGER
+	building_icon = building_robot_assembly_plant
+	
+	possible_pre_triggers = {
+		has_owner = yes
+		is_enslaved = no
+		is_being_purged = no
+		is_being_assimilated = no
+	}
+
+	possible = {
+		drone_job_check_trigger = yes
+	}
+	
+	planet_modifier = {
+		planet_pop_assembly_add = 1
+		planet_amenities_no_happiness_add = 5
+	} 
+
+	resources = {
+		category = planet_pop_assemblers
+		produces = {
+			engineering_research = 1
+		}
+		upkeep = {
+			minerals = 3
+		}
+	}
+	
+	weight = {
+		weight = @spawner_drone_job_weight
+		modifier = {
+			factor = 40
+			exists = owner
+			owner = { has_valid_civic = civic_machine_assimilator }
+			has_trait = trait_cybernetic
+		}
+		modifier = {
+			factor = 0.5 # job is less useful if pop control is active, but still gives amenities
+			planet = {
+				has_modifier = planet_population_control_gestalt
+			}
+		}
+		modifier = {
+			factor = 1.25
+			OR = {
+				has_trait = trait_charismatic
+				has_trait = trait_robot_emotion_emulators
+			}
+		}
+		modifier = {
+			factor = 0.9
+			OR = {
+				has_trait = trait_repugnant
+				has_trait = trait_robot_uncanny
+			}
+		}
+	}
+}
+
+coordinator = {
+	category = complex_drone
+	condition_string = DRONE_JOB_TRIGGER
+	building_icon = building_machine_capital
+	
+	possible_pre_triggers = {
+		has_owner = yes
+		is_enslaved = no
+		is_being_purged = no
+		is_being_assimilated = no
+	}
+
+	possible = {
+		drone_job_check_trigger = yes
+	}	
+	
+	planet_modifier = {
+		planet_jobs_simple_drone_produces_mult = 0.01
+	}
+
+	triggered_planet_modifier = {
+		potential = {
+			planet = { has_modifier = planet_artifact_relays_machine }
+		}
+		modifier = {
+			planet_stability_add = 2
+			planet_jobs_simple_drone_produces_mult = 0.01
+		}
 	}
 	
 	resources = {
 		category = planet_jobs
+		produces = {
+			unity = 3
+			society_research = 1
+			physics_research = 1
+			engineering_research = 1 
+		}
+		upkeep = {
+			energy = 3
+		}
+	}	
+	
+	weight = {
+		weight = @synapse_drone_job_weight
+		modifier = {
+			factor = 0.9
+			exists = owner
+			years_passed < 1
+			owner = { has_valid_civic = civic_machine_assimilator }
+			has_trait = trait_cybernetic
+		}		
+	}
+}
+
+synapse_drone = {
+	category = complex_drone
+	condition_string = DRONE_JOB_TRIGGER
+	building_icon = building_hive_capital
+	
+	possible_pre_triggers = {
+		has_owner = yes
+		is_enslaved = no
+		is_being_purged = no
+		is_being_assimilated = no
+	}
+
+	possible = {
+		drone_job_check_trigger = yes
+	}
+
+	triggered_planet_modifier = {
+		potential = {
+			planet = { has_modifier = planet_artifact_relays_hivemind }
+		}
+		modifier = {
+			planet_stability_add = 2
+			planet_jobs_simple_drone_produces_mult = 0.01
+		}
+	}
+
+	resources = {
+		category = planet_jobs
+		produces = {
+			unity = 3
+			society_research = 3
+		}
 		upkeep = {
 			trigger = {
 				is_lithoid = no
 			}
-			food = 4
+			food = 2
+			energy = 2
 		}
 		upkeep = {
 			trigger = {
 				is_lithoid = yes
 			}
-			minerals = 10
+			minerals = 2
+			energy = 2
 		}
 	}
 	
 	weight = {
-		weight = 50000
+		weight = @synapse_drone_job_weight
+		modifier = {
+			factor = 0.9
+			exists = owner
+			years_passed < 1
+			owner = { has_valid_civic = civic_machine_assimilator }
+			has_trait = trait_cybernetic
+		}		
 	}
 }
 
@@ -59,158 +750,115 @@ brain_drone = {
 	}
 
 	possible = {
-		or = {
-			has_job = brain_drone
-			retile_job_seeking = yes
-		}
 		drone_job_check_trigger = yes
-		owner = { is_hive_empire = yes }
 	}
 
-	############################################################ Brain Drone Production/Upkeep
+	resources = {
+		category = planet_researchers
+		produces = {	
+			physics_research = 4
+			engineering_research = 4
+			society_research = 4
+		}
+		upkeep = {
+			minerals = 6
+		}		
+	}
 	
+	weight = {
+		weight = @complex_drone_job_weight
+		modifier = {
+			factor = 3
+			has_trait = trait_erudite
+		}
+		modifier = {
+			factor = 2
+			has_trait = trait_intelligent
+		}
+		modifier = {
+			factor = 1.5
+			OR = {
+				has_trait = trait_natural_engineers
+				has_trait = trait_natural_physicists
+				has_trait = trait_natural_sociologists
+			}
+		}	
+		modifier = {
+			factor = 0.65
+			OR = {
+				has_trait = trait_syncretic_proles
+				has_trait = trait_presapient_proles	
+			}
+		}
+		modifier = {
+			factor = 0.9
+			exists = owner
+			years_passed < 1
+			owner = { has_valid_civic = civic_machine_assimilator }
+			has_trait = trait_cybernetic
+		}		
+		modifier = {
+			factor = 0
+			planet = {
+				owner = {
+					is_ai = yes
+					has_resource = { type = minerals amount < 500 }
+				}
+			}
+		}
+	}
+}
+
+calculator = {
+	category = complex_drone
+	condition_string = DRONE_JOB_TRIGGER
+	building_icon = building_research_lab_1
+	
+	possible_pre_triggers = {
+		has_owner = yes
+		is_enslaved = no
+		is_being_purged = no
+		is_being_assimilated = no
+	}
+
+	possible = {
+		drone_job_check_trigger = yes
+	}
+
 	resources = {
 		category = planet_researchers
 		produces = {
-			physics_research = 2.5
-			engineering_research = 2.5
-			society_research = 2.5
-			unity = 2.5
+			physics_research = 4
+			engineering_research = 4
+			society_research = 4
 		}
 		upkeep = {
-			consumer_goods = 2.5
-		}		
-		produces = {
-			trigger = { planet = { has_building = building_research_lab_1 } }
-			physics_research = 2.5
-			engineering_research = 2.5
-			society_research = 2.5
-		}
-		upkeep = {
-			trigger = { planet = { has_building = building_research_lab_1 } }
-			consumer_goods = 1.25
-		}		
-		produces = {
-			trigger = { planet = { has_building = building_research_lab_2 } }
-			physics_research = 5
-			engineering_research = 5
-			society_research = 5
-		}
-		upkeep = {
-			trigger = { planet = { has_building = building_research_lab_2 } }
-			consumer_goods = 2.5
-		}		
-		produces = {
-			trigger = { planet = { has_building = building_research_lab_3 } }
-			physics_research = 7.5
-			engineering_research = 7.5
-			society_research = 7.5
-		}
-		upkeep = {
-			trigger = { planet = { has_building = building_research_lab_3 } }
-			consumer_goods = 3.75
-		}		
-		produces = {
-			trigger = { planet = { has_building = building_institute } }
-			physics_research = 2.5
-			engineering_research = 2.5
-			society_research = 2.5
-		}
-		upkeep = {
-			trigger = { planet = { has_building = building_institute } }
-			consumer_goods = 1.25
-		}		
-		produces = {
-			trigger = { planet = { OR = {
-				has_building = building_hive_node
-				has_building = building_uplink_node
-			} } }
-			unity = 2.5
-		}
-		upkeep = {
-			trigger = { planet = { OR = {
-				has_building = building_hive_node
-				has_building = building_uplink_node
-			} } }
-			consumer_goods = 1.25
-		}		
-		produces = {
-			trigger = { planet = { OR = {
-				has_building = building_hive_cluster
-				has_building = building_network_junction
-			} } }
-			unity = 5
-		}
-		upkeep = {
-			trigger = { planet = { OR = {
-				has_building = building_hive_cluster
-				has_building = building_network_junction
-			} } }
-			consumer_goods = 2.5
-		}		
-		produces = {
-			trigger = { planet = { OR = {
-				has_building = building_hive_confluence
-				has_building = building_system_conflux
-			} } }
-			unity = 7.5
-		}
-		upkeep = {
-			trigger = { planet = { OR = {
-				has_building = building_hive_confluence
-				has_building = building_system_conflux
-			} } }
-			consumer_goods = 3.75
+			minerals = 6
 		}		
 	}
-
-	############################################################ Brain Drone Pollution
-	
-	planet_modifier = {
-		planet_amenities_no_happiness_add = 15
-	}
-	triggered_planet_modifier = {
-		potential = { planet = { has_building = building_research_lab_1 } }
-		modifier = { planet_amenities_no_happiness_add = 7.5 }
-	}
-	triggered_planet_modifier = {
-		potential = { planet = { has_building = building_research_lab_2 } }
-		modifier = { planet_amenities_no_happiness_add = 15 }
-	}
-	triggered_planet_modifier = {
-		potential = { planet = { has_building = building_research_lab_3 } }
-		modifier = { planet_amenities_no_happiness_add = 22.5 }
-	}
-	triggered_planet_modifier = {
-		potential = { planet = { has_building = building_institute } }
-		modifier = { planet_amenities_no_happiness_add = 7.5 }
-	}
-	triggered_planet_modifier = {
-		potential = { planet = { OR = {
-			has_building = building_hive_node
-			has_building = building_uplink_node
-		} } }
-		modifier = { planet_amenities_no_happiness_add = 7.5 }
-	}
-	triggered_planet_modifier = {
-		potential = { planet = { OR = {
-			has_building = building_hive_cluster
-			has_building = building_network_junction
-		} } }
-		modifier = { planet_amenities_no_happiness_add = 15 }
-	}
-	triggered_planet_modifier = {
-		potential = { planet = { OR = {
-			has_building = building_hive_confluence
-			has_building = building_system_conflux
-		} } }
-		modifier = { planet_amenities_no_happiness_add = 22.5 }
-	}
-	
-	############################################################ Brain Drone Job Weight
 	
 	weight = {
-		weight = 20
+		weight = @complex_drone_job_weight
+		modifier = {
+			factor = 2
+			has_trait = trait_robot_logic_engines
+		}
+		modifier = {
+			factor = 0.9
+			exists = owner
+			years_passed < 1
+			owner = { has_valid_civic = civic_machine_assimilator }
+			has_trait = trait_cybernetic
+		}		
+		modifier = {
+			factor = 0
+			planet = {
+				owner = {
+					is_ai = yes
+					has_resource = { type = minerals amount < 500 }
+				}
+			}
+		}
 	}
 }
 
@@ -228,121 +876,222 @@ artisan_drone = {
 
 	possible = {
 		drone_job_check_trigger = yes
-		or = {
-			has_job = artisan_drone
-			retile_job_seeking = yes
-		}
-		owner = { is_hive_empire = yes }
 	}
 	
-	############################################################ Factory Drone Production/Upkeep
+	resources = {
+		category = planet_artisans
+		produces = {
+			consumer_goods = 8
+		}		
+		upkeep = {
+			minerals = 8
+		}
+	}	
 	
+	weight = {
+		weight = 5000
+		modifier = {
+			factor = 0.9
+			exists = owner
+			years_passed < 1
+			owner = { has_valid_civic = civic_machine_assimilator }
+			has_trait = trait_cybernetic
+		}
+		modifier = {
+			factor = 0
+			jobs_work_minerals_goods = yes
+		}
+	}
+}
+
+fabricator = {
+	category = complex_drone
+	condition_string = DRONE_JOB_TRIGGER
+	building_icon = building_foundry_1
+	
+	possible_pre_triggers = {
+		has_owner = yes
+		is_enslaved = no
+		is_being_purged = no
+		is_being_assimilated = no
+	}
+
+	possible = {
+		drone_job_check_trigger = yes
+	}
+
 	resources = {
 		category = planet_metallurgists
 		produces = {
-			consumer_goods = 2.5
-			alloys = 2.5
+			alloys = 4
 		}
 		upkeep = {
-			minerals = 10
-		}
-		produces = {
-			trigger = { planet = { has_building = building_factory_1 } }
-			consumer_goods = 2.5
-		}
-		upkeep = {
-			trigger = { planet = { has_building = building_factory_1 } }
-			minerals = 5
-		}
-		produces = {
-			trigger = { planet = { has_building = building_factory_2 } }
-			consumer_goods = 5
-		}
-		upkeep = {
-			trigger = { planet = { has_building = building_factory_2 } }
-			minerals = 10
-		}
-		produces = {
-			trigger = { planet = { has_building = building_factory_3 } }
-			consumer_goods = 7.5
-		}
-		upkeep = {
-			trigger = { planet = { has_building = building_factory_3 } }
-			minerals = 15
-		}
-		produces = {
-			trigger = { planet = { has_building = building_foundry_1 } }
-			alloys = 2.5
-		}
-		upkeep = {
-			trigger = { planet = { has_building = building_foundry_1 } }
-			minerals = 5
-		}
-		produces = {
-			trigger = { planet = { has_building = building_foundry_2 } }
-			alloys = 5
-		}
-		upkeep = {
-			trigger = { planet = { has_building = building_foundry_2 } }
-			minerals = 10
-		}
-		produces = {
-			trigger = { planet = { has_building = building_foundry_3 } }
-			alloys = 7.5
-		}
-		upkeep = {
-			trigger = { planet = { has_building = building_foundry_3 } }
-			minerals = 15
-		}
-		produces = {
-			trigger = { planet = { has_building = building_ministry_production } }
-			alloys = 2.5
-			consumer_goods = 2.5
-		}
-		upkeep = {
-			trigger = { planet = { has_building = building_ministry_production } }
-			minerals = 10
+			minerals = 8
 		}
 	}
-
-	############################################################ Engineer Pollution
 	
-	planet_modifier = {
-		planet_amenities_no_happiness_add = 30
-	}
-	triggered_planet_modifier = {
-		potential = { planet = { has_building = building_factory_1 } }
-		modifier = { planet_amenities_no_happiness_add = 15 }
-	}
-	triggered_planet_modifier = {
-		potential = { planet = { has_building = building_factory_2 } }
-		modifier = { planet_amenities_no_happiness_add = 30 }
-	}
-	triggered_planet_modifier = {
-		potential = { planet = { has_building = building_factory_3 } }
-		modifier = { planet_amenities_no_happiness_add = 45 }
-	}
-	triggered_planet_modifier = {
-		potential = { planet = { has_building = building_foundry_1 } }
-		modifier = { planet_amenities_no_happiness_add = 15 }
-	}
-	triggered_planet_modifier = {
-		potential = { planet = { has_building = building_foundry_2 } }
-		modifier = { planet_amenities_no_happiness_add = 30 }
-	}
-	triggered_planet_modifier = {
-		potential = { planet = { has_building = building_foundry_3 } }
-		modifier = { planet_amenities_no_happiness_add = 45 }
-	}
-	triggered_planet_modifier = {
-		potential = { planet = { has_building = building_ministry_production } }
-		modifier = { planet_amenities_no_happiness_add = 30 }
-	}
-
-	############################################################ Engineer Job Weight
-
 	weight = {
-		weight = 20
+		weight = @complex_drone_job_weight
+		modifier = {
+			factor = 0.9
+			exists = owner
+			years_passed < 1
+			owner = { has_valid_civic = civic_machine_assimilator }
+			has_trait = trait_cybernetic
+		}
+		modifier = {
+			factor = 0
+			jobs_work_minerals = yes
+		}
+	}
+}
+
+alloy_drone = {
+	category = complex_drone
+	condition_string = DRONE_JOB_TRIGGER
+	building_icon = building_foundry_1
+	
+	possible_pre_triggers = {
+		has_owner = yes
+		is_enslaved = no
+		is_being_purged = no
+		is_being_assimilated = no
+	}
+
+	possible = {
+		drone_job_check_trigger = yes
+	}
+
+	resources = {
+		category = planet_metallurgists
+		produces = {
+			alloys = 3
+		}
+		upkeep = {
+			minerals = 6
+		}
+	}
+	
+	weight = {
+		weight = @complex_drone_job_weight
+		modifier = {
+			factor = 0
+			jobs_work_minerals = yes
+		}
+	}
+}
+
+chemist_drone = {
+	category = complex_drone
+	condition_string = DRONE_JOB_TRIGGER
+	building_icon = building_chemical_plant
+	
+	possible_pre_triggers = {
+		has_owner = yes
+		is_enslaved = no
+		is_being_purged = no
+		is_being_assimilated = no
+	}
+
+	possible = {
+		drone_job_check_trigger = yes
+	}
+	
+	resources = {
+		category = planet_chemists
+		produces = {
+			volatile_motes = 2
+		}		
+		upkeep = {
+			minerals = 10
+		}	
+	}
+	
+	weight = {
+		weight = @complex_drone_job_weight
+		modifier = {
+			factor = 0.9
+			exists = owner
+			years_passed < 1
+			owner = { has_valid_civic = civic_machine_assimilator }
+			has_trait = trait_cybernetic
+		}
+	}
+}
+
+translucer_drone = {
+	category = complex_drone
+	condition_string = DRONE_JOB_TRIGGER
+	building_icon = building_crystal_plant
+	
+	possible_pre_triggers = {
+		has_owner = yes
+		is_enslaved = no
+		is_being_purged = no
+		is_being_assimilated = no
+	}
+
+	possible = {
+		drone_job_check_trigger = yes
+	}
+
+	resources = {
+		category = planet_translucers
+		produces = {
+			rare_crystals = 2
+		}		
+		upkeep = {
+			minerals = 10
+		}	
+	}
+	
+	weight = {
+		weight = @complex_drone_job_weight
+		modifier = {
+			factor = 0.9
+			exists = owner
+			years_passed < 1
+			owner = { has_valid_civic = civic_machine_assimilator }
+			has_trait = trait_cybernetic
+		}
+	}
+}
+
+gas_refiner_drone = {
+	category = complex_drone
+	condition_string = DRONE_JOB_TRIGGER
+	building_icon = building_refinery
+	
+	possible_pre_triggers = {
+		has_owner = yes
+		is_enslaved = no
+		is_being_purged = no
+		is_being_assimilated = no
+	}
+
+	possible = {
+		drone_job_check_trigger = yes
+	}
+
+	resources = {
+		category = planet_refiners
+		produces = {
+			exotic_gases = 2
+		}		
+		upkeep = {
+			minerals = 10
+		}
+	}
+	
+	weight = {
+		weight = @complex_drone_job_weight
+		modifier = {
+			factor = 0.9
+			exists = owner
+			years_passed < 1
+			owner = { has_valid_civic = civic_machine_assimilator }
+			has_trait = trait_cybernetic
+		}
 	}
 }
 
@@ -360,61 +1109,57 @@ patrol_drone = {
 
 	possible = {
 		drone_job_check_trigger = yes
-		or = {
-			has_job = patrol_drone
-			retile_job_seeking = yes
-		}
-		owner = { is_hive_empire = yes }
 	}
 	
-	pop_modifier = {
-		pop_defense_armies_add = 6
+	resources = {
+		category = planet_jobs
+		produces = {
+			unity = 1
+		}	
 	}
 	
 	planet_modifier = {
-		planet_crime_add = -25
-		planet_amenities_no_happiness_add = 25
-	}
+		planet_crime_no_happiness_add = -20
+	}	
 
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = { has_civic = civic_police_state }
-		}
-		modifier = {
-			planet_stability_add = 1
-		}		
+	pop_modifier = {
+		pop_defense_armies_add = 2
 	}
-	
-	triggered_pop_modifier = {
-		potential = {
-			exists = owner
-			owner = { has_policy_flag = criminal_common_law }
-		}
-		pop_defense_armies_add = -4
-	}
-	
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = { has_ascension_perk = ap_mind_over_matter }
-		}
-		modifier = {
-			planet_crime_add = -10
-			planet_amenities_no_happiness_add = 10
-			planet_stability_add = 2
-		}		
-	}
-
+		
 	weight = {
-		weight = 20
+		weight = @complex_drone_job_weight
+		modifier = {
+			factor = 50
+			planet = { planet_crime > 22 }
+		}
+		modifier = {
+			weight = 20
+			exists = owner
+			owner = { is_at_war = yes }
+		}
+		modifier = {
+			factor = 3
+			has_trait = trait_resilient
+		}
+		modifier = {
+			factor = 3
+			has_trait = trait_very_strong
+		}
+		modifier = {
+			factor = 2
+			has_trait = trait_strong
+		}
+		modifier = {
+			factor = 0.5
+			has_trait = trait_weak
+		}
 	}
 }
 
-warrior_drone = {
+crystal_mining_drone = {	
 	category = complex_drone
 	condition_string = DRONE_JOB_TRIGGER
-	building_icon = building_stronghold
+	building_icon = building_crystal_mines
 	
 	possible_pre_triggers = {
 		has_owner = yes
@@ -425,110 +1170,103 @@ warrior_drone = {
 
 	possible = {
 		drone_job_check_trigger = yes
-		or = {
-			has_job = warrior_drone
-			retile_job_seeking = yes
-		}
-		owner = { is_hive_empire = yes }
-	}
-	
-	pop_modifier = {
-		pop_defense_armies_add = 6
-	}
-	
-	country_modifier = {
-		country_naval_cap_add = 10
-	}
-	planet_modifier = {
-		planet_amenities_no_happiness_add = 20
-	}
-	
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = { has_policy_flag = criminal_military_police }
-		}
-		planet_crime_add = -15
-		planet_amenities_no_happiness_add = 25
-	}
-	
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = { has_civic = civic_citizen_service }
-		}
-		modifier = {
-			planet_stability_add = 1
-		}		
 	}
 
-	triggered_country_modifier = {
-		potential = {
-			exists = owner 
-			owner = { has_technology = "tech_ground_defense_planning" }
+	resources = {
+		category = planet_jobs
+		produces = {
+			rare_crystals = 2
 		}
-		modifier = {
-			country_naval_cap_add = 5
+		upkeep = {
+			energy = 1
 		}
-	}
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = { has_technology = "tech_ground_defense_planning" }
-		}
-		modifier = {
-			planet_amenities_no_happiness_add = 10
-		}
-	}
-
-	triggered_country_modifier = {
-		potential = {
-			exists = owner 
-			owner = { has_technology = "tech_global_defense_grid" }
-		}
-		modifier = {
-			country_naval_cap_add = 5
-		}
-	}
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = { has_technology = "tech_global_defense_grid" }
-		}
-		modifier = {
-			planet_amenities_no_happiness_add = 10
-		}
-	}
-	triggered_pop_modifier = {
-		potential = {
-			exists = owner
-			owner = { has_technology = tech_global_defense_grid }
-		}
-		pop_defense_armies_add = 2
-	}
+	}	
 	
-	triggered_country_modifier = {
-		potential = {
-			exists = owner
-			owner = { has_ascension_perk = ap_mind_over_matter }
-		}
-		modifier = {
-			country_naval_cap_add = 5
-		}		
-	}
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = { has_ascension_perk = ap_mind_over_matter }
-		}
-		modifier = {
-			planet_amenities_no_happiness_add = 10
-			planet_stability_add = 2
-		}		
-	}
-
 	weight = {
-		weight = 20
+		weight = @complex_drone_job_weight
+		modifier = {
+			factor = 1.1
+			exists = owner
+			years_passed < 1
+			owner = { has_valid_civic = civic_machine_assimilator }
+			has_trait = trait_cybernetic
+		}		
+	}
+}
+
+mote_harvesting_drone = {	
+	category = complex_drone
+	condition_string = DRONE_JOB_TRIGGER
+	building_icon = building_mote_harvesters
+	
+	possible_pre_triggers = {
+		has_owner = yes
+		is_enslaved = no
+		is_being_purged = no
+		is_being_assimilated = no
+	}
+
+	possible = {
+		drone_job_check_trigger = yes
+	}
+
+	resources = {
+		category = planet_jobs
+		produces = {
+			volatile_motes = 2
+		}
+		upkeep = {
+			energy = 1
+		}		
+	}	
+	
+	weight = {
+		weight = @complex_drone_job_weight
+		modifier = {
+			factor = 1.1
+			exists = owner
+			years_passed < 1
+			owner = { has_valid_civic = civic_machine_assimilator }
+			has_trait = trait_cybernetic
+		}			
+	}
+}
+
+gas_extraction_drone = {	
+	category = complex_drone
+	condition_string = DRONE_JOB_TRIGGER
+	building_icon = building_gas_extractors
+	
+	possible_pre_triggers = {
+		has_owner = yes
+		is_enslaved = no
+		is_being_purged = no
+		is_being_assimilated = no
+	}
+
+	possible = {
+		drone_job_check_trigger = yes
+	}
+
+	resources = {
+		category = planet_jobs
+		produces = {
+			exotic_gases = 2
+		}
+		upkeep = {
+			energy = 1
+		}		
+	}	
+	
+	weight = {
+		weight = @complex_drone_job_weight
+		modifier = {
+			factor = 1.1
+			exists = owner
+			years_passed < 1
+			owner = { has_valid_civic = civic_machine_assimilator }
+			has_trait = trait_cybernetic
+		}			
 	}
 }
 
@@ -546,57 +1284,45 @@ mining_drone = {
 
 	possible = {
 		drone_job_check_trigger = yes
-		or = {
-			has_job = mining_drone
-			retile_job_seeking = yes
-		}
-		owner = { is_hive_empire = yes }
 	}
 
 	resources = {
 		category = planet_miners
 		produces = {
-			minerals = 10
-		}
-		produces = {
-			trigger = { planet = { has_building = building_mineral_purification_plant } }
-			minerals = 10
-		}
-		produces = {
-			trigger = { planet = { has_building = building_mineral_purification_hub } }
-			minerals = 20
-		}
-		produces = {
-			trigger = { owner = { has_civic = civic_mining_guilds } }
-			unity = 3
-		}
-	}	
+			minerals = 4
+		}	
+	}
 	
-	planet_modifier = {
-		planet_amenities_no_happiness_add = 30
-	}
-	triggered_planet_modifier = {
-		potential = { planet = { has_building = building_mineral_purification_plant } }
-		modifier = { planet_amenities_no_happiness_add = 30 }
-	}
-	triggered_planet_modifier = {
-		potential = { planet = { has_building = building_mineral_purification_hub } }
-		modifier = { planet_amenities_no_happiness_add = 60 }
-	}
-
-
-	triggered_pop_modifier = {
-		potential = {
-			exists = owner
-			owner = { has_civic = civic_warrior_culture }
+	weight = {
+		weight = @simple_drone_job_weight
+		modifier = {
+			factor = 2
+			OR = {
+				has_trait = trait_industrious
+				has_trait = trait_robot_power_drills
+			}		
 		}
 		modifier = {
-			pop_defense_armies_add = 2
-		}		
-	}
-
-	weight = {
-		weight = 10
+			factor = 1.1
+			exists = owner
+			years_passed < 1
+			owner = { has_valid_civic = civic_machine_assimilator }
+			has_trait = trait_cybernetic
+		}
+		modifier = {
+			factor = 1.2
+			has_job = mining_drone
+		}
+		modifier = {
+			factor = 0.9
+			NOT = { has_job = mining_drone }
+			owner = {
+				has_monthly_income = {
+					resource = minerals
+					value > 85
+				}
+			}
+		}
 	}
 }
 
@@ -614,56 +1340,59 @@ agri_drone = {
 
 	possible = {
 		drone_job_check_trigger = yes
-		or = {
-			has_job = agri_drone
-			retile_job_seeking = yes
-		}
-		owner = { is_hive_empire = yes }
 	}
 
 	resources = {
 		category = planet_farmers
 		produces = {
-			food = 4
+			food = 6
 		}
 		produces = {
-			trigger = { planet = { has_building = building_food_processing_facility } }
-			food = 4
+			trigger = { 
+				owner = {
+					is_robot_empire = yes
+				}
+			}
+			food = -1
 		}
-		produces = {
-			trigger = { planet = { has_building = building_food_processing_center } }
-			food = 8
-		}
-		produces = {
-			trigger = { owner = { has_civic = civic_agrarian_idyll } }
-			unity = 3
-		}
-	}	
+	}
 	
-	planet_modifier = {
-		planet_amenities_no_happiness_add = 30
-	}
-	triggered_planet_modifier = {
-		potential = { planet = { has_building = building_food_processing_facility } }
-		modifier = { planet_amenities_no_happiness_add = 30 }
-	}
-	triggered_planet_modifier = {
-		potential = { planet = { has_building = building_food_processing_center } }
-		modifier = { planet_amenities_no_happiness_add = 60 }
-	}
-
-	triggered_pop_modifier = {
-		potential = {
-			exists = owner
-			owner = { has_civic = civic_warrior_culture }
+	weight = {
+		weight = @simple_drone_job_weight
+		modifier = {
+			factor = 2
+			OR = {
+				has_trait = trait_agrarian
+				has_trait = trait_robot_harvesters
+			}		
 		}
 		modifier = {
-			pop_defense_armies_add = 2
+			factor = 0.9
+			NOT = { has_job = mining_drone }
+			owner = {
+				has_monthly_income = {
+					resource = food
+					value > 50
+				}
+			}
+		}
+		modifier = {
+			factor = 1.2
+			has_job = agri_drone
+		}
+		modifier = {
+			factor = 0.9
+			owner = {
+				is_robot_empire = yes
+			}
+		}	
+		modifier = {
+			factor = 1.1
+			exists = owner
+			years_passed < 1
+			owner = { has_valid_civic = civic_machine_assimilator }
+			has_trait = trait_cybernetic
 		}		
-	}
-
-	weight = {
-		weight = 10		
 	}
 }
 
@@ -681,52 +1410,53 @@ technician_drone = {
 
 	possible = {
 		drone_job_check_trigger = yes
-		or = {
-			has_job = technician_drone
-			retile_job_seeking = yes
-		}
-		owner = { is_hive_empire = yes }
 	}
 
 	resources = {
 		category = planet_technician
 		produces = {
-			energy = 10
+			energy = 4
 		}
 		produces = {
-			trigger = { planet = { has_building = building_energy_grid } }
-			energy = 10
+			trigger = { 
+				owner = {
+					is_robot_empire = yes
+				}
+			}
+			energy = 2
 		}
-		produces = {
-			trigger = { planet = { has_building = building_energy_nexus } }
-			energy = 20
-		}
 	}
-
-	planet_modifier = {
-		planet_amenities_no_happiness_add = 30
-	}
-	triggered_planet_modifier = {
-		potential = { planet = { has_building = building_energy_grid } }
-		modifier = { planet_amenities_no_happiness_add = 30 }
-	}
-	triggered_planet_modifier = {
-		potential = { planet = { has_building = building_energy_nexus } }
-		modifier = { planet_amenities_no_happiness_add = 60 }
-	}
-
-	triggered_pop_modifier = {
-		potential = {
-			exists = owner
-			owner = { has_civic = civic_warrior_culture }
+	
+	weight = {
+		weight = @simple_drone_job_weight
+		modifier = {
+			factor = 2
+			OR = {
+				has_trait = trait_robot_superconductive
+				has_trait = trait_ingenious
+			}		
 		}
 		modifier = {
-			pop_defense_armies_add = 2
+			factor = 0.9
+			NOT = { has_job = mining_drone }
+			owner = {
+				has_monthly_income = {
+					resource = energy
+					value > 50
+				}
+			}
+		}
+		modifier = {
+			factor = 1.2
+			has_job = technician_drone
+		}
+		modifier = {
+			factor = 1.1
+			exists = owner
+			years_passed < 1
+			owner = { has_valid_civic = civic_machine_assimilator }
+			has_trait = trait_cybernetic
 		}		
-	}
-
-	weight = {
-		weight = 10	
 	}
 }
 
@@ -744,151 +1474,168 @@ maintenance_drone = {
 
 	possible = {
 		drone_job_check_trigger = yes
-		or = {
-			has_job = maintenance_drone
-			retile_job_seeking = yes
-		}
-		owner = { is_hive_empire = yes }
 	}
 	
 	planet_modifier = {
-		planet_amenities_no_happiness_add = -50
+		planet_amenities_no_happiness_add = 4
 	}
 	triggered_planet_modifier = {
-		potential = { planet = { has_deposit = retile_deposit_waste_reprocessing } }
-		modifier = { planet_amenities_no_happiness_add = -50 }
-	}
-	triggered_planet_modifier = {
-		potential = { planet = { has_building = building_maintenance_depot } }
-		modifier = { planet_amenities_no_happiness_add = -50 }
-	}
-	triggered_planet_modifier = {
-		potential = { planet = {
-			has_building = building_maintenance_depot
-			has_deposit = retile_deposit_waste_reprocessing
-		} }
-		modifier = { planet_amenities_no_happiness_add = -50 }
-	}
-	triggered_planet_modifier = {
-		potential = { planet = { has_building = building_maintenance_depot_2 } }
-		modifier = { planet_amenities_no_happiness_add = -100 }
-	}
-	triggered_planet_modifier = {
-		potential = { planet = {
-			has_building = building_maintenance_depot_2
-			has_deposit = retile_deposit_waste_reprocessing
-		} }
-		modifier = { planet_amenities_no_happiness_add = -100 }
-	}
-	
-	resources = {
-		category = planet_custodians
-		produces = {
-			society_research = 2.5
-		}
-		produces = {
-			trigger = { planet = { has_building = building_maintenance_depot } }
-			society_research = 2.5
-		}
-		produces = {
-			trigger = { planet = {
-				has_building = building_maintenance_depot
-				has_deposit = retile_deposit_waste_reprocessing
-			} }
-			society_research = 2.5
-		}
-		produces = {
-			trigger = { planet = { has_building = building_maintenance_depot_2 } }
-			society_research = 5
-		}
-		produces = {
-			trigger = { planet = {
-				has_building = building_maintenance_depot_2
-				has_deposit = retile_deposit_waste_reprocessing
-			} }
-			society_research = 2.5
-		}
-		produces = {
-			trigger = { planet = { has_building = building_solar_panels } }
-			energy = 10
-		}
-		produces = {
-			trigger = { planet = { has_building = building_recycling_center } }
-			minerals = 10
-		}
-		produces = {
-			trigger = { planet = { has_building = building_hydroponics_farm } }
-			food = 4
-		}
-		produces = {
-			trigger = { planet = {
-				has_building = building_solar_panels
-				has_deposit = retile_deposit_waste_reprocessing
-			} }
-			energy = 10
-		}
-		produces = {
-			trigger = { planet = {
-				has_building = building_recycling_center
-				has_deposit = retile_deposit_waste_reprocessing
-			} }
-			minerals = 10
-		}
-		produces = {
-			trigger = { planet = {
-				has_building = building_hydroponics_farm
-				has_deposit = retile_deposit_waste_reprocessing
-			} }
-			food = 4
-		}
-	}
-	
-	triggered_planet_modifier = {
-		potential = { planet = { has_building = building_solar_panels } }
-		modifier = { planet_amenities_no_happiness_add = 30 }
-	}
-	triggered_planet_modifier = {
-		potential = { planet = { has_building = building_recycling_center } }
-		modifier = { planet_amenities_no_happiness_add = 30 }
-	}
-	triggered_planet_modifier = {
-		potential = { planet = { has_building = building_hydroponics_farm } }
-		modifier = { planet_amenities_no_happiness_add = 30 }
-	}
-
-	triggered_planet_modifier = {
-		potential = { planet = {
-			has_building = building_solar_panels
-			has_deposit = retile_deposit_waste_reprocessing
-		} }
-		modifier = { planet_amenities_no_happiness_add = 30 }
-	}
-	triggered_planet_modifier = {
-		potential = { planet = {
-			has_building = building_recycling_center
-			has_deposit = retile_deposit_waste_reprocessing
-		} }
-		modifier = { planet_amenities_no_happiness_add = 30 }
-	}
-	triggered_planet_modifier = {
-		potential = { planet = {
-			has_building = building_hydroponics_farm
-			has_deposit = retile_deposit_waste_reprocessing
-		} }
-		modifier = { planet_amenities_no_happiness_add = 30 }
-	}
-
-	triggered_pop_modifier = {
 		potential = {
-			exists = owner
-			owner = { has_civic = civic_warrior_culture }
+			OR = {
+				has_trait = trait_robot_emotion_emulators
+				has_trait = trait_charismatic
+			}
 		}
 		modifier = {
-			pop_defense_armies_add = 2
+			planet_amenities_no_happiness_add = 1
 		}
 	}
-
+	triggered_planet_modifier = {
+		potential = {
+			OR = {
+				has_trait = trait_robot_uncanny
+				has_trait = trait_repugnant
+			}
+		}
+		modifier = {
+			planet_amenities_no_happiness_add = 1
+		}
+	}		
+	
 	weight = {
-		weight = 10	
+		weight = 1
+		modifier = {
+			weight = 200
+			OR = {
+				planet = { free_amenities < 7 }
+			has_job = maintenance_drone
+			}
+		}
+		modifier = {
+			factor = 2
+			OR = {
+				has_trait = trait_robot_emotion_emulators
+				has_trait = trait_charismatic
+			}
+		}
+		modifier = {
+			factor = 0.5
+			OR = {
+				has_trait = trait_robot_uncanny
+				has_trait = trait_repugnant
+			}
+		}
+		modifier = {
+			factor = 1.1
+			exists = owner
+			years_passed < 1
+			owner = { has_valid_civic = civic_machine_assimilator }
+			has_trait = trait_cybernetic
+		}
+		modifier = {
+			factor = 0.1
+			NOT = { has_job = maintenance_drone }
+			planet = {
+				free_amenities > 5
+			}
+		}		
+	}
+}
+
+warrior_drone = {
+	category = simple_drone
+	condition_string = DRONE_JOB_TRIGGER
+	building_icon = building_stronghold
+	
+	country_modifier = {
+		country_naval_cap_add = 4
+	}
+	
+	triggered_country_modifier = {
+		potential = {
+			planet = {
+				exists = owner 
+				owner = { has_technology = "tech_ground_defense_planning" }
+			}
+		}
+		modifier = {
+			country_naval_cap_add = 2
+		}
+	}
+	
+	pop_modifier = {
+		pop_defense_armies_add = 3
+	}
+	
+	triggered_planet_modifier = {
+		potential = {
+			planet = {
+				OR = {
+					has_modifier = compliance_protocols
+					has_modifier = hunter_killer_drones
+				}			
+			}
+		}
+		modifier = {
+			planet_stability_add = 5
+		}
+	}
+	
+	possible_pre_triggers = {
+		has_owner = yes
+		is_enslaved = no
+		is_being_purged = no
+		is_being_assimilated = no
+	}
+
+	possible = {
+		drone_job_check_trigger = yes
+	}
+	
+	weight = {
+		weight = 5
+		modifier = {
+			weight = 100
+			exists = owner
+			owner = { is_at_war = yes }
+		}
+		modifier = {
+			factor = 10
+			planet = {
+				OR = {
+					has_modifier = compliance_protocols
+					has_modifier = hunter_killer_drones
+				}
+			}
+		}
+		modifier = {
+			factor = 4
+			has_trait = trait_resilient
+		}	
+		modifier = {
+			factor = 4
+			has_trait = trait_very_strong
+		}	
+		modifier = {
+			factor = 3
+			has_trait = trait_strong
+		}	
+		modifier = {
+			factor = 0.5
+			has_trait = trait_weak
+		}	
+		modifier = {
+			factor = 0.9
+			exists = owner
+			years_passed < 1
+			owner = { has_valid_civic = civic_machine_assimilator }
+			has_trait = trait_cybernetic
+		}
+		modifier = {
+			weight = 0
+			factor = 0
+			planet = { count_pops = { limit = { } count < 12 } }
+			owner = { is_ai = yes }
+		}		
 	}
 }

--- a/common/static_modifiers/retile_growth_malus_modifiers.txt
+++ b/common/static_modifiers/retile_growth_malus_modifiers.txt
@@ -1,3 +1,5 @@
+### should also affect robot assembler job upkeep
+
 retile_growth_malus_2 = {
 	pop_growth_speed_reduction = 0.1
 	planet_pop_assembly_reduction = 0.1


### PR DESCRIPTION
If the effect gets a discount, why shouldn't also the job upkeep get the discount?

If we use "job upkeep mult" modifiers, other factors that reduce job upkeep will result in a wrong calculation. For example, if you have a robot assembler job upkeep -15% modifier, your robot assembler will have no upkeep at all on 30+ growth malus.