### PR TITLE
Prescripted Countries Update

### DIFF
--- a/prescripted_countries/88_megacorp_prescripted_countries.txt
+++ b/prescripted_countries/88_megacorp_prescripted_countries.txt
@@ -31,6 +31,7 @@ kilik = {
 	authority = "auth_democratic"
 	government = "gov_communal_parity"
 	civics = { "civic_shared_burden" "civic_functional_architecture" }
+	origin = "origin_default"
 	
 	planet_name = "PRESCRIPTED_planet_name_kilik"
 	planet_class = "pc_tropical"
@@ -86,6 +87,7 @@ orbis = {
 		plural = "PRESCRIPTED_species_plural_orbis"
 		adjective = "PRESCRIPTED_species_adjective_orbis"
 		name_list = "REP1"
+		trait = "trait_reptile"
 		trait = "trait_charismatic"
 		trait = "trait_adaptive"
 		trait = "trait_enduring"
@@ -102,6 +104,7 @@ orbis = {
 	authority = "auth_corporate"
 	government = "gov_megacorporation"
 	civics = { "civic_brand_loyalty" "civic_media_conglomerate" }
+	origin = "origin_default"
 	
 	planet_name = "PRESCRIPTED_planet_name_orbis"
 	planet_class = "pc_ocean"
@@ -114,7 +117,7 @@ orbis = {
 	empire_flag = {
 		icon = {
 			category = "corporate"
-			file= "corporate_01.dds"
+			file = "corporate_01.dds"
 		}
 		background = {
 			category = "backgrounds"
@@ -172,6 +175,7 @@ chinorr = {
 	authority = "auth_corporate"
 	government = gov_megacorporation
 	civics = { "civic_private_prospectors" "civic_ruthless_competition" }
+	origin = "origin_default"
 
 	ethic = "ethic_militarist"
 	ethic = "ethic_fanatic_materialist"
@@ -226,6 +230,7 @@ hazbuzan = {
 		plural = "PRESCRIPTED_species_plural_hazbuzan"
 		adjective = "PRESCRIPTED_species_adjective_hazbuzan"
 		name_list = "REP3"
+		trait = "trait_reptile"
 		trait = "trait_ingenious"
 		trait = "trait_thrifty"
 		trait = "trait_deviants"
@@ -239,6 +244,7 @@ hazbuzan = {
 	authority = "auth_corporate"
 	government = "gov_criminal_syndicate"
 	civics = { "civic_criminal_heritage" "civic_franchising" }
+	origin = "origin_default"
 	
 	planet_name = "PRESCRIPTED_planet_name_hazbuzan"
 	planet_class = "pc_savannah"

--- a/prescripted_countries/91_utopia_prescripted_countries.txt
+++ b/prescripted_countries/91_utopia_prescripted_countries.txt
@@ -27,8 +27,9 @@ xanid = {
 		plural = "PRESCRIPTED_secondary_species_plural_xanid"
 		adjective = "PRESCRIPTED_secondary_species_adjective_xanid"
 		name_list = "REP2"
+		trait = "trait_reptile"
 		trait = "trait_syncretic_proles"
-		trait = "trait_strong"
+		trait = "trait_giant"
 		trait = "trait_industrious"
 		trait = "trait_slow_learners"
 		trait = "trait_fleeting"
@@ -47,7 +48,8 @@ xanid = {
 	government = "gov_constitutional_dictatorship"
 	ethic = "ethic_fanatic_authoritarian"
 	ethic = "ethic_xenophobe"
-	civics = { "civic_corvee_system" }
+	civics = { "civic_corvee_system" "civic_cutthroat_politics"	}
+	origin = "origin_syncretic_evolution"
 	
 	graphical_culture = "arthropoid_01"
 	city_graphical_culture = "arthropoid_01"
@@ -96,6 +98,7 @@ lokken = {
 		plural = "PRESCRIPTED_species_plural_lokken"
 		adjective = "PRESCRIPTED_species_adjective_lokken"
 		name_list = "REP2"
+		trait = "trait_reptile"
 		trait = "trait_natural_engineers"
 		trait = "trait_talented"
 		trait = "trait_quick_learners"
@@ -104,7 +107,8 @@ lokken = {
 
 	ethic = "ethic_egalitarian"
 	ethic = "ethic_fanatic_materialist"
-	civics = { "civic_technocracy" }
+	civics = { "civic_technocracy" "civic_meritocracy" }
+	origin = "origin_mechanists"
 	authority = "auth_democratic"
 	government = "gov_rational_consensus"
 	planet_name = "PRESCRIPTED_planet_name_lokken"
@@ -142,6 +146,74 @@ lokken = {
 		clothes = 3
 		ruler_title = "PRESCRIPTED_ruler_title_lokken"
 		ruler_title_female = "PRESCRIPTED_ruler_title_lokken"
+		leader_class = ruler
+	}
+}
+
+
+# Ix'Idar # is now a hive mind
+ixidar = {
+	name = "ixidar"
+	adjective = "PRESCRIPTED_adjective_ixidar"
+	spawn_enabled = yes # yes / no / always
+	
+	playable = has_utopia # scripted_triggers
+	
+	species = {
+		class = "ART"
+		portrait = "art12"
+		name = "PRESCRIPTED_species_name_ixidar"
+		plural = "PRESCRIPTED_species_plural_ixidar"
+		adjective = "PRESCRIPTED_species_adjective_ixidar"
+		name_list = "HIVE"
+		trait = "trait_arthropoid"
+		trait = "trait_hive_mind"
+		trait = "trait_rapid_breeders"
+		trait = "trait_strong"
+		trait = "trait_fleeting"
+	}
+	
+	ship_prefix = "PRESCRIPTED_ship_prefix_ixidar"
+	
+	planet_name = "PRESCRIPTED_planet_name_ixidar"
+	planet_class = "pc_arctic"
+	system_name = "PRESCRIPTED_system_name_ixidar"
+	
+	room = "personality_hive_mind_room"
+
+	ethic = ethic_gestalt_consciousness
+	authority = "auth_hive_mind"
+	government = gov_hive_mind
+	civics = { "civic_hive_natural_neural_network" "civic_hive_pooled_knowledge" }
+	origin = origin_default
+	
+	graphical_culture = "arthropoid_01"
+	city_graphical_culture = "arthropoid_01"
+	
+	empire_flag = {
+		icon= {
+			category = "ornate"
+			file = "flag_ornate_18.dds"
+		}
+		background= {
+			category = "backgrounds"
+			file = "00_solid.dds"
+		}
+		colors={
+			"dark_grey"
+			"black"
+			"null"
+			"null"
+		}
+	}
+	
+	ruler = {
+		name = "PRESCRIPTED_ruler_name_ixidar"
+		gender = male
+		portrait = "art12"
+		texture = -1
+		clothes = 2
+		ruler_title = "PRESCRIPTED_ruler_title_ixidar"
 		leader_class = ruler
 	}
 }

--- a/prescripted_countries/99_prescripted_countries.txt
+++ b/prescripted_countries/99_prescripted_countries.txt
@@ -13,8 +13,9 @@ tzynn = {
 		plural = "PRESCRIPTED_species_plural_tzynn"
 		adjective = "PRESCRIPTED_species_adjective_tzynn"
 		name_list = "REP1"
-		trait = "trait_strong"
-		trait = "trait_resilient"
+		trait = "trait_reptile"
+		trait = "trait_giant"
+		trait = "trait_reptile_camouflage"
 		trait = "trait_rapid_breeders"
 		trait = "trait_decadent"
 		trait = "trait_deviants"
@@ -25,6 +26,7 @@ tzynn = {
 	authority = "auth_imperial"
 	civics = { "civic_police_state" "civic_slaver_guilds" }
 	government = gov_star_empire
+	origin = "origin_default"
 
 	ethic = "ethic_authoritarian"
 	ethic = "ethic_fanatic_militarist"
@@ -92,6 +94,7 @@ yondar = {
 	authority = "auth_imperial"
 	civics = { "civic_imperial_cult" "civic_aristocratic_elite" }
 	government = gov_divine_empire
+	origin = "origin_default"
 
 	ethic = "ethic_authoritarian"
 	ethic = "ethic_spiritualist"
@@ -142,6 +145,7 @@ iferyx = {
 		plural = "PRESCRIPTED_species_plural_iferyx"
 		adjective = "PRESCRIPTED_species_adjective_iferyx"
 		name_list = "MAM3"
+		trait = "trait_mammal"
 		trait = "trait_thrifty"
 		trait = "trait_communal"
 		trait = "trait_deviants"
@@ -158,6 +162,7 @@ iferyx = {
 	authority = "auth_oligarchic"
 	civics = { "civic_corporate_dominion" "civic_shadow_council" }
 	government = gov_trade_league
+	origin = "origin_default"
 
 	ethic = "ethic_egalitarian"
 	ethic = "ethic_spiritualist"
@@ -220,6 +225,8 @@ glebsig = {
 	authority = "auth_oligarchic"
 	civics = { "civic_exalted_priesthood" "civic_efficient_bureaucracy" }
 	government = "gov_holy_tribunal"
+	origin = "origin_default"
+
 	planet_name = "PRESCRIPTED_planet_name_glebsig"
 	planet_class ="pc_alpine"
 	system_name = "PRESCRIPTED_system_name_glebsig"
@@ -283,6 +290,7 @@ jehetma = {
 	authority = "auth_dictatorial"
 	civics = { "civic_environmentalist" "civic_philosopher_king" }
 	government = gov_elective_monarchy
+	origin = "origin_default"
 
 	ethic = "ethic_authoritarian"
 	ethic = "ethic_fanatic_pacifist"
@@ -331,9 +339,10 @@ scyldari = {
 		plural = "PRESCRIPTED_species_plural_scyldari"
 		adjective = "PRESCRIPTED_species_adjective_scyldari"
 		name_list = "MAM1"
+		trait = "trait_mammal"
 		trait = "trait_charismatic"
 		trait = "trait_natural_sociologists"
-		trait = "trait_weak"
+		trait = "trait_sedentary"
 	}
 	
 	ship_prefix = "PRESCRIPTED_ship_prefix_scyldari"
@@ -347,6 +356,7 @@ scyldari = {
 	authority = "auth_democratic"
 	civics = { "civic_environmentalist" "civic_free_haven" }
 	government = gov_theocratic_republic
+	origin = "origin_default"
 
 	ethic = "ethic_spiritualist"
 	ethic = "ethic_pacifist"
@@ -413,6 +423,7 @@ kel_azaan = {
 	authority = "auth_oligarchic"
 	civics = { "civic_warrior_culture" "civic_citizen_service" }
 	government = gov_citizen_stratocracy
+	origin = "origin_default"
 
 	ethic = "ethic_egalitarian"
 	ethic = "ethic_fanatic_militarist"
@@ -475,6 +486,8 @@ blorg={
 	authority = "auth_oligarchic"
 	civics = { "civic_free_haven" "civic_distinguished_admiralty" }
 	government = gov_military_junta
+	origin = "origin_default"
+	
 	planet_name="PRESCRIPTED_planet_name_blorg"
 	planet_class="pc_tropical"
 	system_name="PRESCRIPTED_system_name_blorg"


### PR DESCRIPTION
**Additions:** 
- Origins copied from vanilla files where absent
- Absent civics copied from vanilla files for Xanid and Lokken due to Syncretic Evolution and Mechanists becoming origins
- Ix'Idar hivemind from vanilla utopia file with arthropoid trait (although doesn't work due to rabid breeders, strong, and fleeting traits not available for the arthropoid archetype)
- Reptile trait to species with the reptile archetype
- Mammal trait to species with the mammal archetype
- Minor fix of a forgotten space for consistency.

**Trait Exchanges/Switches:**
- Strong trait (which isn't available to reptiles) for giant trait in the Xanid's secondary reptilian species
- Strong trait for giant trait and resilient trait (which also isn't available) for reptile camouflage in the Tyznn reptilian species
- Weak trait (which isn't available to mammals) for sedentary trait (for now) in the Scydari mammalian species

**Of note:**
The _Kilik_ (in megacorp_prescripted_countries file) and _Jehetma_ (in prescripted_countries file) both don't work still due to the combined value of your traits exceeding the available trait points. Wasn't sure what would be considered an approved change to them, so left their traits alone. The _Ix'Idar_ also doesn't work for the reasons stated above under **Additions**.