### PR TITLE
Integrate compatibility for ACEP - Extended First Contact

### DIFF
--- a/events/on_action_events.txt
+++ b/events/on_action_events.txt
@@ -2090,6 +2090,16 @@ country_event = {
 				}
 			}
 		}
+		### Start of ACEPEFC compatibility triggers
+		if = {
+			limit = {
+				event_target:contact_empire = { has_country_flag = acep_empire }
+			}
+			hidden_effect = {
+				country_event = { id = acep.00000 }
+			}
+		}
+		### End of ACEPEFC
 	}
 }
 
@@ -4208,6 +4218,16 @@ country_event = {
 				}
 			}
 		}
+		### Start of ACEPEFC compatibility triggers
+		if = {
+			limit = {
+				event_target:contact_empire = { has_country_flag = acep_empire }
+			}
+			hidden_effect = {
+				country_event = { id = acep.00000 }
+			}
+		}
+		### End of ACEPEFC
 	}
 }
 


### PR DESCRIPTION
Adds compatibility for the extended first contact event with empires from the [Adv. Custom Empires Pack - Extended First Contact](https://steamcommunity.com/sharedfiles/filedetails/?id=925031358) mod. The trigger is limited to having the `acep_empire` flag, so it should be harmless when not using the mod. From my testing of just such a scenario, I noticed no change in my first contact with empires. Feel free to let me know if this is not the case or if it interferes with something else.

While this is technically optional to add to Stellaris Immortal, I figured I would suggest the integration of it given no adverse effects and the benefit for end-users of both mods.