### PR TITLE
Vertimnus Merchant Republic

### DIFF
--- a/common/governments/00_governments.txt
+++ b/common/governments/00_governments.txt
@@ -1432,6 +1432,41 @@ gov_bandit_kingdom = {
 	}
 }
 
+# Merchant Republic
+gov_merchant_republic = {
+	ruler_title = RT_DOGE
+	ruler_title_female = RT_DOGE
+	
+	should_force_rename = yes
+
+	election_candidates = {
+		modifier = {
+			add = 100
+			leader_class = ruler
+		}
+		modifier = {
+			add = 10
+			leader_class = governor
+		}
+	}
+
+	possible = {
+		has_valid_civic = civic_merchant_guilds
+	}
+
+	weight = {
+		base = 400
+		modifier = {
+			factor = 2
+			has_ethic = ethic_authoritarian
+		}
+		modifier = {
+			factor = 4
+			has_ethic = ethic_fanatic_authoritarian
+		}
+	}
+}
+
 # Bandit Commune
 gov_bandit_commune = {
 	ruler_title = RT_WARLORD

--- a/common/governments/00_governments.txt
+++ b/common/governments/00_governments.txt
@@ -1458,11 +1458,7 @@ gov_merchant_republic = {
 		base = 400
 		modifier = {
 			factor = 2
-			has_ethic = ethic_authoritarian
-		}
-		modifier = {
-			factor = 4
-			has_ethic = ethic_fanatic_authoritarian
+			has_ethic = ethic_fanatic_materialist
 		}
 	}
 }

--- a/common/governments/civics/00_civics.txt
+++ b/common/governments/civics/00_civics.txt
@@ -866,11 +866,15 @@ civic_merchant_guilds = {
 			}
 		}
 		ethics = {
-			NOR = {
-				text = civic_tooltip_not_egalitarian
-				value = ethic_egalitarian
-				value = ethic_fanatic_egalitarian
+			OR = {
+				value = ethic_materialist
+				value = ethic_fanatic_materialist
 			}
+			OR = {
+				value = ethic_authoritarian
+				value = ethic_fanatic_authoritarian
+			}
+			NOT = { value = ethic_fanatic_xenophobe }
 		}
 	}
 	random_weight = {

--- a/common/governments/civics/00_civics.txt
+++ b/common/governments/civics/00_civics.txt
@@ -858,7 +858,20 @@ civic_merchant_guilds = {
 				value = civic_technocracy
 				value = civic_shared_burden
 			}
-		}		
+		}
+		authority = {
+			OR = {
+				value = auth_oligarchic
+				value = auth_dictatorial
+			}
+		}
+		ethics = {
+			NOR = {
+				text = civic_tooltip_not_egalitarian
+				value = ethic_egalitarian
+				value = ethic_fanatic_egalitarian
+			}
+		}
 	}
 	random_weight = {
 		base = 2

--- a/common/random_names/00_empire_names.txt
+++ b/common/random_names/00_empire_names.txt
@@ -1240,6 +1240,21 @@ empire_name_parts_list = {
 	}
 }
 
+# Merchant Republic
+empire_name_parts_list = {
+	key = "merchant_republic"
+	parts = {
+		"Mercantile Republic" = 1
+		"Mercantile League" = 1
+		"Trade Federation" = 1
+		"Republic" = 1
+		"League" = 1
+		"Union" = 1
+		"Federation" = 1
+		"Confederation" = 1
+	}
+}
+
 # Megachurch
 empire_name_parts_list = {
 	key = "oligarchic_megachurch"
@@ -4834,6 +4849,70 @@ empire_name_format = {
 	noun = "[This.Capital.GetName]"
 	prefix_format = "[This.Capital.GetName] <imperial_celestial>"
 	# Human People's Republic
+}
+
+# Merchant Republic 1
+empire_name_format = {
+	random_weight = {
+		factor = 0
+		modifier = {
+			add = 5
+			OR = {
+				has_government = "gov_merchant_republic"
+			}
+			is_pirate = no
+			is_primitive = no
+			NOT = { is_country_type = fallen_empire }
+			NOT = { is_country_type = awakened_fallen_empire }
+		}
+	}
+	format = "format.merchant_republic.1"
+	noun = "[This.GetSpeciesName]"
+	prefix_format = "[This.GetSpeciesName] <merchant_republic>"
+	# Human Republic
+	
+}
+
+# Merchant Republic 2
+empire_name_format = {
+	random_weight = {
+		factor = 0
+		modifier = {
+			add = 5
+			OR = {
+				has_government = "gov_merchant_republic"
+			}
+			is_pirate = no
+			is_primitive = no
+			NOT = { is_country_type = fallen_empire }
+			NOT = { is_country_type = awakened_fallen_empire }
+		}
+	}
+	format = "format.merchant_republic.2"
+	noun = "[This.Capital.GetName]"
+	prefix_format = "[This.Capital.GetName] <merchant_republic>"
+	# Republic of Earth
+}
+
+# Merchant Republic 3
+empire_name_format = {
+	random_weight = {
+		factor = 0
+		modifier = {
+			add = 5
+			OR = {
+				has_government = "gov_merchant_republic"
+			}
+			is_pirate = no
+			is_primitive = no
+			NOT = { is_country_type = fallen_empire }
+			NOT = { is_country_type = awakened_fallen_empire }
+		}
+	}
+	format = "format.merchant_republic.3"
+	noun = "[This.Capital.System.GetName]"
+	prefix_format = "[This.Capital.System.GetName] <merchant_republic>"
+	# Republic of Sol
 }
 
 # Bandit Kingdom

--- a/localisation/replace/retile_government_l_english.yml
+++ b/localisation/replace/retile_government_l_english.yml
@@ -105,6 +105,9 @@
  gov_fascist:0 "Fascist"
  gov_fascist_desc:0 "A government with a single powerful leader at the top held together by highly centralized corporate power."
  RT_GOVERNMENT_HEAD:0 "Head of the Government"
+ gov_merchant_republic:0 "Merchant Republic"
+ gov_merchant_republic_desc:0 "A plutocratic form of republic where the government is under the effective control of a group of wealthy merchant families who wield the apparatus of state to promote their common commercial interests."
+ RT_DOGE:0 "Doge"
 # Origins
  origin_immortal:0 "Immortal Emperor"
  origin_immortal_desc:0 "Your society has united under the rule of an immortal god emperor, who now seeks to expand their reach into the stars."

--- a/localisation_synced/retile_empire_formats.yml
+++ b/localisation_synced/retile_empire_formats.yml
@@ -1,0 +1,4 @@
+﻿l_default:
+ format.merchant_republic.1: "[This.GetSpeciesName] <merchant_republic>"
+ format.merchant_republic.2: "<merchant_republic> of [This.Capital.GetName]"
+ format.merchant_republic.3: "<merchant_republic> of [This.Capital.System.GetName]"


### PR DESCRIPTION
Adds a government type for the Merchant Guilds civic - Merchant Republic - that was erroneously missing from the mod
Updates the ethic requirements for the civic to be any Auth, any Mat, not F. Xenophobe 
Updated authority requirements for the civic to be oli_dict to befit the new government type and match historical merchant republics
