### PR TITLE
Switcing Traits of Prescripted Countries

### DIFF
--- a/prescripted_countries/88_megacorp_prescripted_countries.txt
+++ b/prescripted_countries/88_megacorp_prescripted_countries.txt
@@ -17,9 +17,9 @@ kilik = {
 		plural = "PRESCRIPTED_species_plural_kilik"
 		adjective = "PRESCRIPTED_species_adjective_kilik"
 		name_list = "AVI4"
-		trait="trait_communal"
-		trait="trait_natural_philosopher"
-		trait="trait_fleeting"
+		trait = "trait_communal"
+		trait = "trait_natural_philosopher"
+		trait = "trait_fleeting"
 	}
 	
 	room = "personality_erudite_explorers_room"

--- a/prescripted_countries/88_megacorp_prescripted_countries.txt
+++ b/prescripted_countries/88_megacorp_prescripted_countries.txt
@@ -17,10 +17,9 @@ kilik = {
 		plural = "PRESCRIPTED_species_plural_kilik"
 		adjective = "PRESCRIPTED_species_adjective_kilik"
 		name_list = "AVI4"
-		trait = "trait_communal"
-		trait = "trait_natural_philosopher"
-		trait = "trait_quick_learners"
-		trait = "trait_fleeting"
+		trait="trait_communal"
+		trait="trait_natural_philosopher"
+		trait="trait_fleeting"
 	}
 	
 	room = "personality_erudite_explorers_room"

--- a/prescripted_countries/91_utopia_prescripted_countries.txt
+++ b/prescripted_countries/91_utopia_prescripted_countries.txt
@@ -168,9 +168,10 @@ ixidar = {
 		name_list = "HIVE"
 		trait = "trait_arthropoid"
 		trait = "trait_hive_mind"
-		trait = "trait_rapid_breeders"
-		trait = "trait_strong"
-		trait = "trait_fleeting"
+		trait = "trait_arthropoid_mandibles"
+		trait = "trait_quick_learners"
+		trait = "trait_arthropoid_wing"
+		trait = "trait_repugnant"
 	}
 	
 	ship_prefix = "PRESCRIPTED_ship_prefix_ixidar"

--- a/prescripted_countries/99_prescripted_countries.txt
+++ b/prescripted_countries/99_prescripted_countries.txt
@@ -273,6 +273,7 @@ jehetma = {
 		plural = "PRESCRIPTED_species_plural_jehetma"
 		adjective = "PRESCRIPTED_species_adjective_jehetma"
 		name_list = "FUN1"
+		trait = "trait_sedentary"
 		trait = "trait_slow_breeders"
 		trait = "trait_ingenious"
 		trait = "trait_communal"


### PR DESCRIPTION
The following empires are causing errors in the log due to the traits they have. I set out to fix them based on their descriptions and portraits. Below, I have summarized their errors, proposed fixes, and reasons for such.

## Kilik Cooperative's Traits
**Problem:** The combined value of chosen traits exceeded the available trait points by one point.

**Solution:** Removed `"trait_quick_learners"` as it least fits the empire description.


## Ix'Idar Star Collective's Traits
**Problem:** `"trait_rapid_breeders"`, `"trait_strong"`, and `"trait_fleeting"` are invalid traits for species archetype: `Arthropoid`.

**Solution:** Removed those traits and replace with semi-equivalent `"trait_arthropoid_wing"` and `"trait_arthropoid_mandibles"`. Added `"trait_repugnant"` and `"trait_quick_learners"` based on trait point requirements and empire description.


## Jehetma Dominion's Traits
**Problem:** The combined value of chosen traits exceeded the available trait points by one point.

**Solution:** Added `"trait_sedentary"` based on empire description.