### PR TITLE
sector housing

### DIFF
--- a/common/sector_focuses/00_focus.txt
+++ b/common/sector_focuses/00_focus.txt
@@ -1,0 +1,30 @@
+# Critially important things goes here, such as amenities, housing and countering crime
+# Should be blocked unless they are not needed
+basic = {
+	hidden = yes
+	clear_blockers = no
+	district = {
+		key = district_housing
+		weight = {
+			weight = 1
+			modifier = {
+				factor = 5
+				free_housing < 1
+			}
+			# Let's not go full spam on this.
+			modifier = {
+				factor = 0
+				free_housing >= 1
+			}
+		}
+	}
+}
+
+#############
+# BALANCED FOCUS
+#############
+balanced = {
+	ai_weight = {
+		weight = 100
+	}
+}


### PR DESCRIPTION
Sector "AI" builds housing if the housing is less then 1 and is set to balanced focus.

------------------------------------------

I wanted to make a decent automation system to reduce micromanagement. I wanted to discuss this on Discord but the changes are so small I just decided to pr it. The reasons are below if you are interested.

Stellaris has a planetary automation system and a sector system. The planetary system are just build templates for buildings with a "priority district." It's based on planet designation. Pretty useless here because there are only 4 building slots. I'm not sure what priority district means but it's probably not useful.

The sector system is much more robust. Being able to build districts and buildings based on a bunch of factors. There is a hard coded flaw tho making it pretty useless unfortunately.

Planets are managed under the sector focus they are under. Even if is planets is prime material for a research planet, for example, the system doesn't care. The flaw is that plates are managed based on their location relative to the sector center and not they planetary designation or properties of the planet.

I tried to mitigate this by setting the sector hyperlane distance to 0. Unfortunately this just makes sectors infinity sized. Same with negative numbers. Even this has a flaw being that there can be multiple planets in a system.

This is something PDX has to fix. Giving sector level logic on a planetary level based on planetary designation would allow for complete automation.

As it stands I can't see a way to make sector AI useful in any way. It can be set to hyperlane distance 1. This would allow some level of control at least but I find this too situational to be useful.