### PR TITLE
ship_modifier

### DIFF
--- a/common/starbase_buildings/00_starbase_buildings.txt
+++ b/common/starbase_buildings/00_starbase_buildings.txt
@@ -10,8 +10,6 @@ courier_network = {
 	station_modifier = {
 		ship_armor_add = 1000
 		starbase_defense_platform_capacity_add = 4
-	}
-	ship_modifier = {
 		ship_fire_rate_mult = 0.50
 		ship_weapon_range_mult = 0.20
 	}
@@ -52,8 +50,6 @@ default_network = {
 	station_modifier = {
 		ship_armor_add = 1000
 		starbase_defense_platform_capacity_add = 4
-	}
-	ship_modifier = {
 		ship_fire_rate_mult = 0.50
 		ship_weapon_range_mult = 0.20
 	}
@@ -91,8 +87,6 @@ patrol_network = {
 		ship_armor_add = 1000
 		starbase_defense_platform_capacity_add = 4
 		ship_piracy_suppression_add = 8
-	}
-	ship_modifier = {
 		ship_fire_rate_mult = 0.50
 		ship_weapon_range_mult = 0.20
 	}


### PR DESCRIPTION
The ship_modifier apply to ships built from this Starbase.

With this ship_modifier block, ships built from Starbases are incredibly stronger than ships obtained from other sources, like Mega Shipyards and the three starting corvettes.

Is this intended?